### PR TITLE
Add Spec.RolloutID and CanaryStatus.ObservedRolloutID fields

### DIFF
--- a/api/v1alpha1/rollout_types.go
+++ b/api/v1alpha1/rollout_types.go
@@ -33,6 +33,9 @@ type RolloutSpec struct {
 	ObjectRef ObjectRef `json:"objectRef"`
 	// rollout strategy
 	Strategy RolloutStrategy `json:"strategy"`
+	// RolloutID should be changed before each workload revision publication.
+	// It is to distinguish consecutive multiple workload publications and rollout progress.
+	RolloutID string `json:"rolloutID,omitempty"`
 }
 
 type ObjectRef struct {
@@ -206,6 +209,8 @@ const (
 type CanaryStatus struct {
 	// observedWorkloadGeneration is the most recent generation observed for this Rollout ref workload generation.
 	ObservedWorkloadGeneration int64 `json:"observedWorkloadGeneration,omitempty"`
+	// ObservedRolloutID will record the newest spec.RolloutID if status.canaryRevision equals to workload.updateRevision
+	ObservedRolloutID string `json:"observedRolloutID,omitempty"`
 	// RolloutHash from rollout.spec object
 	RolloutHash string `json:"rolloutHash,omitempty"`
 	// CanaryService holds the name of a service which selects pods with canary version and don't select any pods with stable version.

--- a/config/crd/bases/rollouts.kruise.io_rollouts.yaml
+++ b/config/crd/bases/rollouts.kruise.io_rollouts.yaml
@@ -80,6 +80,11 @@ spec:
                     - name
                     type: object
                 type: object
+              rolloutID:
+                description: RolloutID should be changed before each workload revision
+                  publication. It is to distinguish consecutive multiple workload
+                  publications and rollout progress.
+                type: string
               strategy:
                 description: rollout strategy
                 properties:
@@ -206,6 +211,10 @@ spec:
                     format: date-time
                     type: string
                   message:
+                    type: string
+                  observedRolloutID:
+                    description: ObservedRolloutID will record the newest spec.RolloutID
+                      if status.canaryRevision equals to workload.updateRevision
                     type: string
                   observedWorkloadGeneration:
                     description: observedWorkloadGeneration is the most recent generation

--- a/pkg/controller/rollout/progressing.go
+++ b/pkg/controller/rollout/progressing.go
@@ -130,6 +130,7 @@ func (r *RolloutReconciler) reconcileRolloutProgressing(rollout *rolloutv1alpha1
 				}
 			}
 		}
+
 	// after the normal completion of rollout, enter into the Finalising process
 	case rolloutv1alpha1.ProgressingReasonFinalising:
 		klog.Infof("rollout(%s/%s) is Progressing, and in reason(%s)", rollout.Namespace, rollout.Name, cond.Reason)

--- a/pkg/controller/rollout/status.go
+++ b/pkg/controller/rollout/status.go
@@ -83,6 +83,7 @@ func (r *RolloutReconciler) updateRolloutStatus(rollout *rolloutv1alpha1.Rollout
 	// which version of deployment is targeted, ObservedWorkloadGeneration that is to compare with the workload generation
 	if newStatus.CanaryStatus != nil && newStatus.CanaryStatus.CanaryRevision != "" &&
 		newStatus.CanaryStatus.CanaryRevision == workload.CanaryRevision {
+		newStatus.CanaryStatus.ObservedRolloutID = rollout.Spec.RolloutID
 		newStatus.CanaryStatus.ObservedWorkloadGeneration = workload.Generation
 	}
 


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
I add these fields is to solve the problem that users cannot judge which workload revision corresponds to the current rollout `CanaryStatus`.

Now, users can change the `Spec.RolloutID` before release, and use 
- `Spec.RolloutID == Status.CanaryStatus.ObservedRolloutID && Status.CanaryStatus.CurrentStepState == "Completed"` to judge whether current rollout progress  is completed.
