### PR TITLE
Add disable switch for Rollout

### DIFF
--- a/api/v1alpha1/rollout_types.go
+++ b/api/v1alpha1/rollout_types.go
@@ -72,6 +72,9 @@ type WorkloadRef struct {
 
 // RolloutStrategy defines strategy to apply during next rollout
 type RolloutStrategy struct {
+	// Disabled means the rollout will be not work, just like it was deleted.
+	// Default value is false
+	Disabled bool `json:"disabled,omitempty"`
 	// Paused indicates that the Rollout is paused.
 	// Default value is false
 	Paused bool `json:"paused,omitempty"`
@@ -212,6 +215,12 @@ const (
 	ProgressingReasonCanceled     = "Canceled"
 	ProgressingReasonPaused       = "Paused"
 
+	// Disabled condition
+	RolloutConditionDisabled RolloutConditionType = "Disabled"
+	// Disabled Reason
+	DisabledReasonDisabling = "InDisabling"
+	DisabledReasonCompleted = "Completed"
+
 	// Terminating condition
 	RolloutConditionTerminating RolloutConditionType = "Terminating"
 	// Terminating Reason
@@ -271,6 +280,8 @@ const (
 	RolloutPhaseProgressing RolloutPhase = "Progressing"
 	// RolloutPhaseTerminating indicates a rollout is terminated
 	RolloutPhaseTerminating RolloutPhase = "Terminating"
+	// RolloutPhaseDisabled indicates a rollout is disabled
+	RolloutPhaseDisabled RolloutPhase = "Disabled"
 )
 
 // +genclient

--- a/config/crd/bases/rollouts.kruise.io_rollouts.yaml
+++ b/config/crd/bases/rollouts.kruise.io_rollouts.yaml
@@ -172,6 +172,10 @@ spec:
                           type: object
                         type: array
                     type: object
+                  disabled:
+                    description: Disabled means the rollout will be not work, just
+                      like it was deleted. Default value is false
+                    type: boolean
                   paused:
                     description: Paused indicates that the Rollout is paused. Default
                       value is false

--- a/pkg/controller/batchrelease/batchrelease_event_handler.go
+++ b/pkg/controller/batchrelease/batchrelease_event_handler.go
@@ -75,7 +75,6 @@ func (p podEventHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingI
 		return
 	}
 
-	klog.Infof("Pod %v ready condition changed, then enqueue", client.ObjectKeyFromObject(newPod))
 	p.enqueue(newPod, q)
 }
 

--- a/pkg/controller/rollout/rollout_controller.go
+++ b/pkg/controller/rollout/rollout_controller.go
@@ -136,6 +136,8 @@ func (r *RolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		recheckTime, err = r.reconcileRolloutProgressing(rollout)
 	case rolloutv1alpha1.RolloutPhaseTerminating:
 		recheckTime, err = r.reconcileRolloutTerminating(rollout)
+	case rolloutv1alpha1.RolloutPhaseDisabled:
+		recheckTime, err = r.reconcileRolloutDisabled(rollout)
 	}
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/webhook/workload/mutating/workload_update_handler.go
+++ b/pkg/webhook/workload/mutating/workload_update_handler.go
@@ -176,7 +176,7 @@ func (h *WorkloadHandler) handleStatefulSetLikeWorkload(newObj, oldObj *unstruct
 		return
 	}
 	// 3. have matched rollout crd
-	rollout, err := h.fetchMatchedRollout(newObj)
+	rollout, err := h.fetchMatchedActiveRollout(newObj)
 	if err != nil {
 		return
 	} else if rollout == nil {
@@ -236,7 +236,7 @@ func (h *WorkloadHandler) handleDeployment(newObj, oldObj *apps.Deployment) (cha
 		return
 	}
 	// 5. have matched rollout crd
-	rollout, err := h.fetchMatchedRollout(newObj)
+	rollout, err := h.fetchMatchedActiveRollout(newObj)
 	if err != nil {
 		return
 	} else if rollout == nil {
@@ -267,7 +267,7 @@ func (h *WorkloadHandler) handleCloneSet(newObj, oldObj *kruiseappsv1alpha1.Clon
 		return
 	}
 	// 3. have matched rollout crd
-	rollout, err := h.fetchMatchedRollout(newObj)
+	rollout, err := h.fetchMatchedActiveRollout(newObj)
 	if err != nil {
 		return
 	} else if rollout == nil {
@@ -288,7 +288,7 @@ func (h *WorkloadHandler) handleCloneSet(newObj, oldObj *kruiseappsv1alpha1.Clon
 	return
 }
 
-func (h *WorkloadHandler) fetchMatchedRollout(obj client.Object) (*appsv1alpha1.Rollout, error) {
+func (h *WorkloadHandler) fetchMatchedActiveRollout(obj client.Object) (*appsv1alpha1.Rollout, error) {
 	oGv := obj.GetObjectKind().GroupVersionKind()
 	rolloutList := &appsv1alpha1.RolloutList{}
 	if err := h.Client.List(context.TODO(), rolloutList, utilclient.DisableDeepCopy,
@@ -298,7 +298,7 @@ func (h *WorkloadHandler) fetchMatchedRollout(obj client.Object) (*appsv1alpha1.
 	}
 	for i := range rolloutList.Items {
 		rollout := &rolloutList.Items[i]
-		if !rollout.DeletionTimestamp.IsZero() || rollout.Spec.ObjectRef.WorkloadRef == nil {
+		if !rollout.DeletionTimestamp.IsZero() || rollout.Spec.Strategy.Disabled || rollout.Spec.ObjectRef.WorkloadRef == nil {
 			continue
 		}
 		ref := rollout.Spec.ObjectRef.WorkloadRef


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR improve the following things:
- Allow users disable Rollout via setting `rollout.spec.strategy.disable=true`, and Rollout will terminate the rollout progression immediately,  and will not work unless rollout.spec.strategy.disable=false`;
- No need manual confirmation any more if all replicas & traffics are updated.