### PR TITLE
Update canary status after the first deployment of rollout

### DIFF
--- a/pkg/controller/rollout/status.go
+++ b/pkg/controller/rollout/status.go
@@ -93,12 +93,37 @@ func (r *RolloutReconciler) updateRolloutStatus(rollout *rolloutv1alpha1.Rollout
 		newStatus.Phase = rolloutv1alpha1.RolloutPhaseHealthy
 		newStatus.Message = "rollout is healthy"
 	case rolloutv1alpha1.RolloutPhaseHealthy:
-		// from healthy to progressing
 		if workload.InRolloutProgressing {
+			// from healthy to progressing
 			klog.Infof("rollout(%s/%s) status phase from(%s) -> to(%s)", rollout.Namespace, rollout.Name, rolloutv1alpha1.RolloutPhaseHealthy, rolloutv1alpha1.RolloutPhaseProgressing)
 			newStatus.Phase = rolloutv1alpha1.RolloutPhaseProgressing
 			cond := util.NewRolloutCondition(rolloutv1alpha1.RolloutConditionProgressing, corev1.ConditionFalse, rolloutv1alpha1.ProgressingReasonInitializing, "Rollout is in Progressing")
 			util.SetRolloutCondition(&newStatus, *cond)
+		} else if workload.IsInStable && newStatus.CanaryStatus == nil {
+			// The following logic is to make PaaS be able to judge whether the rollout is ready
+			// at the first deployment of the Rollout/Workload. For example: generally, a PaaS
+			// platform can use the following code to judge whether the rollout progression is completed:
+			// ```
+			//   if getRolloutID(workload, rollout) == rollout.Status.CanaryStatus.ObservedRolloutID &&
+			//	   rollout.Status.CanaryStatus.CurrentStepState == "Completed" {
+			//	   // do something after rollout
+			//   }
+			//```
+			// But at the first deployment of Rollout/Workload, CanaryStatus isn't set due to no rollout progression,
+			// and PaaS platform cannot judge whether the deployment is completed base on the code above. So we have
+			// to update the status just like the rollout was completed.
+
+			newStatus.CanaryStatus = &rolloutv1alpha1.CanaryStatus{
+				CanaryReplicas:             workload.CanaryReplicas,
+				CanaryReadyReplicas:        workload.CanaryReadyReplicas,
+				ObservedRolloutID:          getRolloutID(workload, rollout),
+				ObservedWorkloadGeneration: workload.Generation,
+				PodTemplateHash:            workload.PodTemplateHash,
+				CanaryRevision:             workload.CanaryRevision,
+				CurrentStepIndex:           int32(len(rollout.Spec.Strategy.Canary.Steps)),
+				CurrentStepState:           rolloutv1alpha1.CanaryStepStateCompleted,
+			}
+			newStatus.Message = "workload deployment is completed"
 		}
 	case rolloutv1alpha1.RolloutPhaseProgressing:
 		cond := util.GetRolloutCondition(newStatus, rolloutv1alpha1.RolloutConditionProgressing)


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
To make PaaS platforms have a consistent experience about judging whether rollout is completed, we have to update the canary status after the first deployment of rollout.

A PaaS can just use the following logic to judge the rollout progression is completed:
`rollout.status.canaryStatus.observedRolloutID == rollout.Spec.RolloutID && rollout.status.canaryStatus.currentStepState=="Completed"`
