### PR TITLE
Allow users add rollout id label to workload

### DIFF
--- a/pkg/controller/rollout/context.go
+++ b/pkg/controller/rollout/context.go
@@ -55,7 +55,7 @@ func newRolloutContext(client client.Client, recorder record.EventRecorder, roll
 		Client:       client,
 		rollout:      rollout,
 		newStatus:    newStatus,
-		batchControl: batchrelease.NewInnerBatchController(client, rollout),
+		batchControl: batchrelease.NewInnerBatchController(client, rollout, getRolloutID(workload, rollout)),
 		workload:     workload,
 		recorder:     recorder,
 	}
@@ -94,4 +94,17 @@ func (r *rolloutContext) podRevisionLabelKey() string {
 		return ""
 	}
 	return r.workload.RevisionLabelKey
+}
+
+func getRolloutID(workload *util.Workload, rollout *rolloutv1alpha1.Rollout) string {
+	if workload != nil {
+		firstChoice := workload.Labels[util.RolloutIDLabel]
+		if firstChoice != "" {
+			return firstChoice
+		}
+	}
+	if rollout != nil {
+		return rollout.Spec.RolloutID
+	}
+	return ""
 }

--- a/pkg/controller/rollout/progressing_test.go
+++ b/pkg/controller/rollout/progressing_test.go
@@ -253,7 +253,7 @@ func TestReCalculateCanaryStepIndex(t *testing.T) {
 				Scheme: scheme,
 				Finder: util.NewControllerFinder(client),
 			}
-			batchControl := batchrelease.NewInnerBatchController(client, cs.getRollout())
+			batchControl := batchrelease.NewInnerBatchController(client, cs.getRollout(), "")
 			newStepIndex, err := reconciler.reCalculateCanaryStepIndex(cs.getRollout(), batchControl)
 			if err != nil {
 				t.Fatalf(err.Error())

--- a/pkg/controller/rollout/rolling.go
+++ b/pkg/controller/rollout/rolling.go
@@ -33,7 +33,7 @@ func (r *RolloutReconciler) doProgressingInRolling(rollout *rolloutv1alpha1.Roll
 
 	// 5. In case of rollout plan changed, recalculate and publishing
 	case isRolloutPlanChanged(rollout):
-		return r.handleRolloutPlanChanged(rollout, newStatus)
+		return r.handleRolloutPlanChanged(rollout, workload, newStatus)
 	}
 
 	return r.handleNormalRolling(rollout, workload, newStatus)
@@ -86,8 +86,8 @@ func (r *RolloutReconciler) handleRollbackInBatches(rollout *rolloutv1alpha1.Rol
 	return nil, nil
 }
 
-func (r *RolloutReconciler) handleRolloutPlanChanged(rollout *rolloutv1alpha1.Rollout, newStatus *rolloutv1alpha1.RolloutStatus) (*time.Time, error) {
-	batchControl := batchrelease.NewInnerBatchController(r.Client, rollout)
+func (r *RolloutReconciler) handleRolloutPlanChanged(rollout *rolloutv1alpha1.Rollout, workload *util.Workload, newStatus *rolloutv1alpha1.RolloutStatus) (*time.Time, error) {
+	batchControl := batchrelease.NewInnerBatchController(r.Client, rollout, getRolloutID(workload, rollout))
 	newStepIndex, err := r.reCalculateCanaryStepIndex(rollout, batchControl)
 	if err != nil {
 		klog.Errorf("rollout(%s/%s) reCalculate Canary StepIndex failed: %s", rollout.Namespace, rollout.Name, err.Error())

--- a/pkg/controller/rollout/status.go
+++ b/pkg/controller/rollout/status.go
@@ -83,7 +83,7 @@ func (r *RolloutReconciler) updateRolloutStatus(rollout *rolloutv1alpha1.Rollout
 	// which version of deployment is targeted, ObservedWorkloadGeneration that is to compare with the workload generation
 	if newStatus.CanaryStatus != nil && newStatus.CanaryStatus.CanaryRevision != "" &&
 		newStatus.CanaryStatus.CanaryRevision == workload.CanaryRevision {
-		newStatus.CanaryStatus.ObservedRolloutID = rollout.Spec.RolloutID
+		newStatus.CanaryStatus.ObservedRolloutID = getRolloutID(workload, rollout)
 		newStatus.CanaryStatus.ObservedWorkloadGeneration = workload.Generation
 	}
 

--- a/test/e2e/rollout_test.go
+++ b/test/e2e/rollout_test.go
@@ -3413,7 +3413,6 @@ var _ = SIGDescribe("Rollout", func() {
 				Name:       "echoserver",
 			}
 			rollout.Spec.Strategy.Canary.TrafficRoutings = nil
-			rollout.Spec.RolloutID = "1"
 			CreateObject(rollout)
 
 			By("Creating workload and waiting for all pods ready...")
@@ -3432,6 +3431,7 @@ var _ = SIGDescribe("Rollout", func() {
 			// workload
 			workload := &appsv1beta1.StatefulSet{}
 			Expect(ReadYamlToObject("./test_data/rollout/advanced_statefulset.yaml", workload)).ToNot(HaveOccurred())
+			workload.Labels[util.RolloutIDLabel] = "1"
 			CreateObject(workload)
 			WaitAdvancedStatefulSetPodsReady(workload)
 
@@ -3499,7 +3499,6 @@ var _ = SIGDescribe("Rollout", func() {
 					},
 				},
 			}
-			rollout.Spec.RolloutID = "1"
 			CreateObject(rollout)
 			By("Creating workload and waiting for all pods ready...")
 			// service
@@ -3513,6 +3512,7 @@ var _ = SIGDescribe("Rollout", func() {
 			// workload
 			workload := &appsv1alpha1.CloneSet{}
 			Expect(ReadYamlToObject("./test_data/rollout/cloneset.yaml", workload)).ToNot(HaveOccurred())
+			workload.Labels[util.RolloutIDLabel] = "1"
 			CreateObject(workload)
 			WaitCloneSetAllPodsReady(workload)
 
@@ -3595,12 +3595,12 @@ var _ = SIGDescribe("Rollout", func() {
 					},
 				},
 			}
-			rollout.Spec.RolloutID = "1"
 			CreateObject(rollout)
 
 			By("Creating workload and waiting for all pods ready...")
 			workload := &appsv1alpha1.CloneSet{}
 			Expect(ReadYamlToObject("./test_data/rollout/cloneset.yaml", workload)).ToNot(HaveOccurred())
+			workload.Labels[util.RolloutIDLabel] = "1"
 			CreateObject(workload)
 			WaitCloneSetAllPodsReady(workload)
 
@@ -3626,15 +3626,10 @@ var _ = SIGDescribe("Rollout", func() {
 			CheckPodBatchLabel(workload.Namespace, workload.Spec.Selector, "1", "2", 1)
 			CheckPodBatchLabel(workload.Namespace, workload.Spec.Selector, "1", "3", 1)
 
-			By("Update rollout id '1' -> to '2'")
-			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
-			rollout.Spec.RolloutID = "2"
-			UpdateRollout(rollout)
-			time.Sleep(10 * time.Second)
-
 			By("Update cloneSet env NODE_NAME from(version2) -> to(version1)")
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
 			newEnvs = mergeEnvVar(workload.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{Name: "NODE_NAME", Value: "version1"})
+			workload.Labels[util.RolloutIDLabel] = "2"
 			workload.Spec.Template.Spec.Containers[0].Env = newEnvs
 			UpdateCloneSet(workload)
 			time.Sleep(10 * time.Second)


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Allow users add rollout id label to workload.

Note: If user set rollout id for both workload and Rollout, the controller will use workload's.