### PR TITLE
[Break] Change rollout id label prefix from apps to rollouts

### DIFF
--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -45,11 +45,11 @@ const (
 const (
 	// RolloutIDLabel is designed to distinguish each workload revision publications.
 	// The value of RolloutIDLabel corresponds Rollout.Spec.RolloutID.
-	RolloutIDLabel = "apps.kruise.io/rollout-id"
+	RolloutIDLabel = "rollouts.kruise.io/rollout-id"
 	// RolloutBatchIDLabel is the label key of batch id that will be patched to pods during rollout.
 	// Only when RolloutIDLabel is set, RolloutBatchIDLabel will be patched.
 	// Users can use RolloutIDLabel and RolloutBatchIDLabel to select the pods that are upgraded in some certain batch and release.
-	RolloutBatchIDLabel = "apps.kruise.io/rollout-batch-id"
+	RolloutBatchIDLabel = "rollouts.kruise.io/rollout-batch-id"
 	// NoNeedUpdatePodLabel will be patched to pod when rollback in batches if the pods no need to rollback
 	NoNeedUpdatePodLabel = "rollouts.kruise.io/no-need-update"
 )


### PR DESCRIPTION
Signed-off-by: mingzhou.swx <mingzhou.swx@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Change rollout id label prefix from `apps.kruise.io/` to `rollouts.kruise.io/`