### PR TITLE
Update k8s registry references

### DIFF
--- a/test/images/image_utils.go
+++ b/test/images/image_utils.go
@@ -72,11 +72,11 @@ func initReg() RegistryList {
 		DockerGluster:           "docker.io/gluster",
 		E2eRegistry:             "gcr.io/kubernetes-e2e-test-images",
 		E2eVolumeRegistry:       "gcr.io/kubernetes-e2e-test-images/volume",
-		PromoterE2eRegistry:     "k8s.gcr.io/e2e-test-images",
-		BuildImageRegistry:      "k8s.gcr.io/build-image",
+		PromoterE2eRegistry:     "registry.k8s.io/e2e-test-images",
+		BuildImageRegistry:      "registry.k8s.io/build-image",
 		InvalidRegistry:         "invalid.com/invalid",
-		GcRegistry:              "k8s.gcr.io",
-		SigStorageRegistry:      "k8s.gcr.io/sig-storage",
+		GcRegistry:              "registry.k8s.io",
+		SigStorageRegistry:      "registry.k8s.io/sig-storage",
 		GcrReleaseRegistry:      "gcr.io/gke-release",
 		PrivateRegistry:         "gcr.io/k8s-authenticated-test",
 		SampleRegistry:          "gcr.io/google-samples",
@@ -297,9 +297,9 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 		registryAndUser = e2eRegistry
 	case "gcr.io/kubernetes-e2e-test-images/volume":
 		registryAndUser = e2eVolumeRegistry
-	case "k8s.gcr.io":
+	case "registry.k8s.io":
 		registryAndUser = gcRegistry
-	case "k8s.gcr.io/sig-storage":
+	case "registry.k8s.io/sig-storage":
 		registryAndUser = sigStorageRegistry
 	case "gcr.io/k8s-authenticated-test":
 		registryAndUser = PrivateRegistry


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Per https://github.com/kubernetes/k8s.io/issues/4780, Kubernetes is migrating its image registry to registry.k8s.io, and this repository is impacted.

We have to update the references of k8s.gcr.io to registry.k8s.io by April 3rd to remain up-to-date.

Here's a quick search for k8s.gcr.io on this repo. [[search result]](https://github.com/search?q=org%3Adapr%20%22k8s.gcr.io%22&type=code). Note that there may be other valid references (like, in the form of generated code, etc) which we have to be aware of.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Special notes for reviews
