### PR TITLE
Siyuan branch

### DIFF
--- a/.github/workflows/e2e-daemonset-1.19.yaml
+++ b/.github/workflows/e2e-daemonset-1.19.yaml
@@ -1,0 +1,110 @@
+name: E2E-DaemonSet-1.19
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request: {}
+  workflow_dispatch: {}
+
+env:
+  # Common versions
+  GO_VERSION: '1.17'
+  KIND_IMAGE: 'kindest/node:v1.19.16'
+  KIND_CLUSTER_NAME: 'ci-testing'
+
+jobs:
+
+  rollout:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          node_image: ${{ env.KIND_IMAGE }}
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          config: ./test/kind-conf.yaml
+      - name: Build image
+        run: |
+          export IMAGE="openkruise/kruise-rollout:e2e-${GITHUB_RUN_ID}"
+          docker build --pull --no-cache . -t $IMAGE
+          kind load docker-image --name=${KIND_CLUSTER_NAME} $IMAGE || { echo >&2 "kind not installed or error loading image: $IMAGE"; exit 1; }
+      - name: Install Kruise
+        run: |
+          set -ex
+          kubectl cluster-info
+          make helm
+          helm repo add openkruise https://openkruise.github.io/charts/
+          helm repo update
+          helm install kruise openkruise/kruise
+          for ((i=1;i<10;i++));
+          do
+            set +e
+            PODS=$(kubectl get pod -n kruise-system | grep '1/1' | grep kruise-controller-manager | wc -l)
+            set -e
+            if [ "$PODS" -eq "2" ]; then
+              break
+            fi
+            sleep 3
+          done
+          set +e
+          PODS=$(kubectl get pod -n kruise-system | grep '1/1' | grep kruise-controller-manager | wc -l)
+          set -e
+          if [ "$PODS" -eq "2" ]; then
+            echo "Wait for kruise-manager ready successfully"
+          else
+            echo "Timeout to wait for kruise-manager ready"
+            exit 1
+          fi
+      - name: Install Kruise Rollout
+        run: |
+          set -ex
+          kubectl cluster-info
+          IMG=openkruise/kruise-rollout:e2e-${GITHUB_RUN_ID} ./scripts/deploy_kind.sh
+          for ((i=1;i<10;i++));
+          do
+            set +e
+            PODS=$(kubectl get pod -n kruise-rollout | grep '1/1' | wc -l)
+            set -e
+            if [ "$PODS" -eq "1" ]; then
+              break
+            fi
+            sleep 3
+          done
+          set +e
+          PODS=$(kubectl get pod -n kruise-rollout | grep '1/1' | wc -l)
+          kubectl get node -o yaml
+          kubectl get all -n kruise-rollout -o yaml
+          set -e
+          if [ "$PODS" -eq "1" ]; then
+            echo "Wait for kruise-rollout ready successfully"
+          else
+            echo "Timeout to wait for kruise-rollout ready"
+            exit 1
+          fi
+      - name: Run E2E Tests
+        run: |
+          export KUBECONFIG=/home/runner/.kube/config
+          make ginkgo
+          set +e
+          ./bin/ginkgo -timeout 60m -v --focus='DaemonSet canary rollout' test/e2e
+          retVal=$?
+          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
+          if [ "${restartCount}" -eq "0" ];then
+              echo "Kruise-rollout has not restarted"
+          else
+              kubectl get pod -n kruise-rollout --no-headers
+              echo "Kruise-rollout has restarted, abort!!!"
+              kubectl get pod -n kruise-rollout --no-headers| awk '{print $1}' | xargs kubectl logs -p -n kruise-rollout
+              exit 1
+          fi
+          exit $retVal

--- a/pkg/controller/batchrelease/control/partitionstyle/daemonset/control.go
+++ b/pkg/controller/batchrelease/control/partitionstyle/daemonset/control.go
@@ -1,0 +1,215 @@
+package daemonset
+
+import (
+	"context"
+	"fmt"
+
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+	"github.com/openkruise/rollouts/api/v1alpha1"
+	batchcontext "github.com/openkruise/rollouts/pkg/controller/batchrelease/context"
+	"github.com/openkruise/rollouts/pkg/controller/batchrelease/control"
+	"github.com/openkruise/rollouts/pkg/controller/batchrelease/control/partitionstyle"
+	"github.com/openkruise/rollouts/pkg/controller/batchrelease/labelpatch"
+	"github.com/openkruise/rollouts/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type realController struct {
+	*util.WorkloadInfo
+	client client.Client
+	pods   []*corev1.Pod
+	key    types.NamespacedName
+	// question 1 : here is DaemonSet or Advanced DaemonSet *apps.DaemonSet *kruiseappsv1alpha1.DaemonSet
+	object *kruiseappsv1alpha1.DaemonSet
+	//
+}
+
+func NewController(cli client.Client, key types.NamespacedName, _ schema.GroupVersionKind) partitionstyle.Interface {
+	return &realController{
+		key:    key,
+		client: cli,
+	}
+}
+
+// GetWorkloadInfo return workload information.
+func (rc *realController) GetWorkloadInfo() *util.WorkloadInfo {
+	return rc.WorkloadInfo
+}
+
+// BuildController will get workload object and parse workload info,
+// and return a initialized controller for workload.
+func (rc *realController) BuildController() (partitionstyle.Interface, error) {
+	if rc.object != nil {
+		return rc, nil
+	}
+	object := &kruiseappsv1alpha1.DaemonSet{}
+	if err := rc.client.Get(context.TODO(), rc.key, object); err != nil {
+		return rc, err
+	}
+	rc.object = object
+
+	//update this function
+	rc.WorkloadInfo = util.ParseWorkload(object)
+	return rc, nil
+}
+
+// ListOwnedPods fetch the pods owned by the workload.
+// Note that we should list pod only if we really need it.
+func (rc *realController) ListOwnedPods() ([]*corev1.Pod, error) {
+	if rc.pods != nil {
+		return rc.pods, nil
+	}
+	var err error
+	// update this
+	rc.pods, err = util.ListOwnedPods(rc.client, rc.object)
+	return rc.pods, err
+}
+
+func (rc *realController) Initialize(release *v1alpha1.BatchRelease) error {
+	if control.IsControlledByBatchRelease(release, rc.object) {
+		return nil
+	}
+
+	// // Set strategy to deployment annotations
+	// strategy := util.GetDeploymentStrategy(rc.object)
+	// rollingUpdate := strategy.RollingUpdate
+	// if rc.object.Spec.Strategy.RollingUpdate != nil {
+	// 	rollingUpdate = rc.object.Spec.Strategy.RollingUpdate
+	// }
+	// strategy = v1alpha1.DeploymentStrategy{
+	// 	Paused:        false,
+	// 	Partition:     intstr.FromInt(0),
+	// 	RollingStyle:  v1alpha1.PartitionRollingStyle,
+	// 	RollingUpdate: rollingUpdate,
+	// }
+
+	// d := rc.object.DeepCopy()
+	// patchData := patch.NewDeploymentPatch()
+	// patchData.InsertLabel(v1alpha1.AdvancedDeploymentControlLabel, "true")
+	// patchData.InsertAnnotation(v1alpha1.DeploymentStrategyAnnotation, util.DumpJSON(&strategy))
+	// patchData.InsertAnnotation(util.BatchReleaseControlAnnotation, util.DumpJSON(metav1.NewControllerRef(
+	// 	release, release.GetObjectKind().GroupVersionKind())))
+
+	// // Disable the native deployment controller
+	// patchData.UpdatePaused(true)
+	// patchData.UpdateStrategy(apps.DeploymentStrategy{Type: apps.RecreateDeploymentStrategyType})
+	// return rc.client.Patch(context.TODO(), d, patchData)
+
+	daemon := util.GetEmptyObjectWithKey(rc.object)
+	owner := control.BuildReleaseControlInfo(release)
+	body := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}},"spec":{"updateStrategy":{"paused":%v,"partition":"%s"}}}`,
+		util.BatchReleaseControlAnnotation, owner, false, "100%")
+	return rc.client.Patch(context.TODO(), daemon, client.RawPatch(types.MergePatchType, []byte(body)))
+}
+
+func (rc *realController) UpgradeBatch(ctx *batchcontext.BatchContext) error {
+	var body string
+	var desired int
+	switch partition := ctx.DesiredPartition; partition.Type {
+	case intstr.Int:
+		desired = int(partition.IntVal)
+		body = fmt.Sprintf(`{"spec":{"updateStrategy":{"partition": %d }}}`, partition.IntValue())
+	case intstr.String:
+		desired, _ = intstr.GetScaledValueFromIntOrPercent(&partition, int(ctx.Replicas), true)
+		body = fmt.Sprintf(`{"spec":{"updateStrategy":{"partition":"%s"}}}`, partition.String())
+	}
+	current, _ := intstr.GetScaledValueFromIntOrPercent(&ctx.CurrentPartition, int(ctx.Replicas), true)
+
+	// current less than desired, which means current revision replicas will be less than desired,
+	// in other word, update revision replicas will be more than desired, no need to update again.
+	if current <= desired {
+		return nil
+	}
+
+	daemon := util.GetEmptyObjectWithKey(rc.object)
+	return rc.client.Patch(context.TODO(), daemon, client.RawPatch(types.MergePatchType, []byte(body)))
+}
+
+func (rc *realController) Finalize(release *v1alpha1.BatchRelease) error {
+	if rc.object == nil {
+		return nil
+	}
+
+	var specBody string
+	// if batchPartition == nil, workload should be promoted.
+	if release.Spec.ReleasePlan.BatchPartition == nil {
+		specBody = `,"spec":{"updateStrategy":{"partition":null,"paused":false}}`
+	}
+
+	body := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null}}%s}`, util.BatchReleaseControlAnnotation, specBody)
+
+	daemon := util.GetEmptyObjectWithKey(rc.object)
+	return rc.client.Patch(context.TODO(), daemon, client.RawPatch(types.MergePatchType, []byte(body)))
+}
+
+func (rc *realController) CalculateBatchContext(release *v1alpha1.BatchRelease) (*batchcontext.BatchContext, error) {
+	rolloutID := release.Spec.ReleasePlan.RolloutID
+	if rolloutID != "" {
+		// if rollout-id is set, the pod will be patched batch label,
+		// so we have to list pod here.
+		if _, err := rc.ListOwnedPods(); err != nil {
+			return nil, err
+		}
+	}
+
+	// current batch index
+	currentBatch := release.Status.CanaryStatus.CurrentBatch
+	// the number of no need update pods that marked before rollout
+	noNeedUpdate := release.Status.CanaryStatus.NoNeedUpdateReplicas
+	// the number of upgraded pods according to release plan in current batch.
+	// rc.Replicas need to change to another value CurrentNumberSchduled or desiredNumberScheduled?
+	// updated is what, node has been updated by prev batch?
+	plannedUpdate := int32(control.CalculateBatchReplicas(release, int(rc.Replicas), int(currentBatch)))
+	// the number of pods that should be upgraded in real
+	desiredUpdate := plannedUpdate
+	// the number of pods that should not be upgraded in real
+	//change rc.replicas
+	desiredStable := rc.Replicas - desiredUpdate
+	//do we need to consider this?
+	// if we should consider the no-need-update pods that were marked before progressing
+	if noNeedUpdate != nil && *noNeedUpdate > 0 {
+		// specially, we should ignore the pods that were marked as no-need-update, this logic is for Rollback scene
+		desiredUpdateNew := int32(control.CalculateBatchReplicas(release, int(rc.Replicas-*noNeedUpdate), int(currentBatch)))
+		desiredStable = rc.Replicas - *noNeedUpdate - desiredUpdateNew
+		desiredUpdate = rc.Replicas - desiredStable
+	}
+
+	// make sure at least one pod is upgrade is canaryReplicas is not "0%"
+	desiredPartition := intstr.FromInt(int(desiredStable))
+	batchPlan := release.Spec.ReleasePlan.Batches[currentBatch].CanaryReplicas
+	if batchPlan.Type == intstr.String {
+		desiredPartition = control.ParseIntegerAsPercentageIfPossible(desiredStable, rc.Replicas, &batchPlan)
+	}
+
+	currentPartition := intstr.FromInt(0)
+	if rc.object.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+		intPartition := *rc.object.Spec.UpdateStrategy.RollingUpdate.Partition
+		currentPartition = intstr.FromInt(int(intPartition))
+	}
+
+	batchContext := &batchcontext.BatchContext{
+		Pods:             rc.pods,
+		RolloutID:        rolloutID,
+		CurrentBatch:     currentBatch,
+		UpdateRevision:   release.Status.UpdateRevision,
+		DesiredPartition: desiredPartition,
+		CurrentPartition: currentPartition,
+		FailureThreshold: release.Spec.ReleasePlan.FailureThreshold,
+		//replica number
+		Replicas:               rc.Replicas,
+		UpdatedReplicas:        rc.Status.UpdatedReplicas,
+		UpdatedReadyReplicas:   rc.Status.UpdatedReadyReplicas,
+		NoNeedUpdatedReplicas:  noNeedUpdate,
+		PlannedUpdatedReplicas: plannedUpdate,
+		DesiredUpdatedReplicas: desiredUpdate,
+	}
+
+	if noNeedUpdate != nil {
+		batchContext.FilterFunc = labelpatch.FilterPodsForUnorderedUpdate
+	}
+	return batchContext, nil
+}

--- a/pkg/controller/batchrelease/control/partitionstyle/daemonset/control.go
+++ b/pkg/controller/batchrelease/control/partitionstyle/daemonset/control.go
@@ -74,31 +74,6 @@ func (rc *realController) Initialize(release *v1alpha1.BatchRelease) error {
 		return nil
 	}
 
-	// // Set strategy to deployment annotations
-	// strategy := util.GetDeploymentStrategy(rc.object)
-	// rollingUpdate := strategy.RollingUpdate
-	// if rc.object.Spec.Strategy.RollingUpdate != nil {
-	// 	rollingUpdate = rc.object.Spec.Strategy.RollingUpdate
-	// }
-	// strategy = v1alpha1.DeploymentStrategy{
-	// 	Paused:        false,
-	// 	Partition:     intstr.FromInt(0),
-	// 	RollingStyle:  v1alpha1.PartitionRollingStyle,
-	// 	RollingUpdate: rollingUpdate,
-	// }
-
-	// d := rc.object.DeepCopy()
-	// patchData := patch.NewDeploymentPatch()
-	// patchData.InsertLabel(v1alpha1.AdvancedDeploymentControlLabel, "true")
-	// patchData.InsertAnnotation(v1alpha1.DeploymentStrategyAnnotation, util.DumpJSON(&strategy))
-	// patchData.InsertAnnotation(util.BatchReleaseControlAnnotation, util.DumpJSON(metav1.NewControllerRef(
-	// 	release, release.GetObjectKind().GroupVersionKind())))
-
-	// // Disable the native deployment controller
-	// patchData.UpdatePaused(true)
-	// patchData.UpdateStrategy(apps.DeploymentStrategy{Type: apps.RecreateDeploymentStrategyType})
-	// return rc.client.Patch(context.TODO(), d, patchData)
-
 	daemon := util.GetEmptyObjectWithKey(rc.object)
 	owner := control.BuildReleaseControlInfo(release)
 	body := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}},"spec":{"updateStrategy":{"paused":%v,"partition":"%s"}}}`,

--- a/pkg/util/parse_utils.go
+++ b/pkg/util/parse_utils.go
@@ -221,6 +221,17 @@ func ParseWorkloadStatus(object client.Object) *WorkloadStatus {
 			StableRevision:     o.Status.CurrentRevision,
 		}
 
+	case *appsv1alpha1.DaemonSet:
+		return &WorkloadStatus{
+			Replicas:           o.Status.DesiredNumberScheduled,
+			ReadyReplicas:      o.Status.NumberReady,
+			AvailableReplicas:  o.Status.NumberAvailable,
+			UpdatedReplicas:    o.Status.UpdatedNumberScheduled,
+			ObservedGeneration: o.Status.ObservedGeneration,
+			UpdateRevision:     o.Status.DaemonSetHash,
+			//StableRevision:       o.Status.CurrentRevision,
+		}
+
 	case *unstructured.Unstructured:
 		return &WorkloadStatus{
 			ObservedGeneration:   int64(parseStatusIntFromUnstructured(o, "observedGeneration")),
@@ -250,6 +261,9 @@ func GetReplicas(object client.Object) int32 {
 		replicas = *o.Spec.Replicas
 	case *appsv1beta1.StatefulSet:
 		replicas = *o.Spec.Replicas
+	// DesiredNumberScheduled type is int
+	case *appsv1alpha1.DaemonSet:
+		replicas = o.Status.DesiredNumberScheduled
 	case *unstructured.Unstructured:
 		replicas = parseReplicasFromUnstructured(o)
 	default:
@@ -304,6 +318,8 @@ func GetMetadata(object client.Object) *metav1.ObjectMeta {
 	case *apps.StatefulSet:
 		return &o.ObjectMeta
 	case *appsv1beta1.StatefulSet:
+		return &o.ObjectMeta
+	case *appsv1alpha1.DaemonSet:
 		return &o.ObjectMeta
 	case *unstructured.Unstructured:
 		return parseMetadataFromUnstructured(o)

--- a/test/e2e/test_data/rollout/daemonset.yaml
+++ b/test/e2e/test_data/rollout/daemonset.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  name: fluentd-elasticsearch
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+spec:
+  selector:
+    matchLabels:
+      name: fluentd-elasticsearch
+  template:
+    metadata:
+      labels:
+        name: fluentd-elasticsearch
+    spec:
+      tolerations:
+      # these tolerations are to have the daemonset runnable on control plane nodes
+      # remove them if your control plane nodes should not run pods
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: fluentd-elasticsearch
+        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      # updateStrategy:
+      #   type: RollingUpdate
+      #   rollingUpdate:
+      #     rollingUpdateType: Standard

--- a/test/e2e/test_data/rollout/rollout_canary_daemonset_base.yaml
+++ b/test/e2e/test_data/rollout/rollout_canary_daemonset_base.yaml
@@ -1,0 +1,21 @@
+apiVersion: rollouts.kruise.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-test
+  # The rollout resource needs to be in the same namespace as the corresponding workload
+  namespace: kube-system
+  # This annotation can help us upgrade the Deployment using partition, just like StatefulSet/CloneSet.
+  annotations:
+    rollouts.kruise.io/rolling-style: partition
+spec:
+  objectRef:
+    # rollout of published workloads, currently only supports Deployment, CloneSet, StatefulSet, Advanced StatefulSet
+    workloadRef:
+      apiVersion: apps.kruise.io/v1alpha1
+      kind: DaemonSet
+      name: fluentd-elasticsearch
+  strategy:
+    canary:
+      steps:
+      - replicas: 1
+      - replicas: 100%

--- a/test/e2e/test_data/rollout/rollout_canary_daemonset_interrupt.yaml
+++ b/test/e2e/test_data/rollout/rollout_canary_daemonset_interrupt.yaml
@@ -1,0 +1,22 @@
+apiVersion: rollouts.kruise.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-test
+  # The rollout resource needs to be in the same namespace as the corresponding workload
+  namespace: kube-system
+  # This annotation can help us upgrade the Deployment using partition, just like StatefulSet/CloneSet.
+  annotations:
+    rollouts.kruise.io/rolling-style: partition
+spec:
+  objectRef:
+    # rollout of published workloads, currently only supports Deployment, CloneSet, StatefulSet, Advanced StatefulSet
+    workloadRef:
+      apiVersion: apps.kruise.io/v1alpha1
+      kind: DaemonSet
+      name: fluentd-elasticsearch
+  strategy:
+    canary:
+      steps:
+      - replicas: 1
+      - replicas: 2
+      - replicas: 100%


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Description
Add DaemonSet e2e tests including 3 cases:
1) Normal rollout update:
   "DaemonSet V1->V2: 1,100% Succeeded"

2) v1 -> v2(interrupt) -> v3
   "V1->V2: Percentage, 1, 2 and continuous release v3"

3) delete rollout during the process
   "V1->V2: 1,100%, but delete rollout crd"

### Ⅱ. Test Process
1) Set up basic environment according to this md:
    https://github.com/openkruise/rollouts/blob/master/docs/contributing/debug.md

2) run kubectl apply -f rollout_canary_daemonset_base.yaml, and rollout_canary_daemonset_base.yaml is under the path:
     test/e2e/test_data/rollout/rollout_canary_daemonset_base.yaml

3) run kubectl apply -f rollout_canary_daemonset_interrupt.yaml, and rollout_canary_daemonset_interrupt.yaml is under the path:
    test/e2e/test_data/rollout/rollout_canary_daemonset_interrupt.yaml

4) run ginkgo -timeout 60m -v --focus="DaemonSet canary rollout" test/e2e under rollouts package.
### Ⅲ. Test Result
All three cases passed
1) 
<img width="1923" alt="Screen Shot 2023-04-27 at 17 06 32" src="https://user-images.githubusercontent.com/95588190/235069449-e20454dd-7a13-4dad-ac0c-b681e33c30a4.png">
2)
<img width="1984" alt="Screen Shot 2023-04-27 at 17 07 32" src="https://user-images.githubusercontent.com/95588190/235069486-32e0771a-0906-4731-aaa6-4dca1bc292ac.png">
3) 
<img width="1893" alt="Screen Shot 2023-04-27 at 17 16 35" src="https://user-images.githubusercontent.com/95588190/235069499-040ee8b6-d2fa-41ba-8759-77b0931f706a.png">
