### PR TITLE
[feature]When the data type of spec.replicas is int, cancel the upper limit

### DIFF
--- a/pkg/webhook/rollout/validating/rollout_create_update_handler.go
+++ b/pkg/webhook/rollout/validating/rollout_create_update_handler.go
@@ -240,9 +240,11 @@ func validateRolloutSpecCanarySteps(steps []appsv1alpha1.CanaryStep, fldPath *fi
 		}
 		if s.Replicas != nil {
 			canaryReplicas, err := intstr.GetScaledValueFromIntOrPercent(s.Replicas, 100, true)
-			if err != nil || canaryReplicas <= 0 || canaryReplicas > 100 {
+			if err != nil ||
+				canaryReplicas <= 0 ||
+				(canaryReplicas > 100 && s.Replicas.Type == intstr.String) {
 				return field.ErrorList{field.Invalid(fldPath.Index(i).Child("CanaryReplicas"),
-					s.Replicas, `canaryReplicas must be positive number with with "0" < canaryReplicas <= "100", or a percentage with "0%" < canaryReplicas <= "100%"`)}
+					s.Replicas, `canaryReplicas must be positive number, or a percentage with "0%" < canaryReplicas <= "100%"`)}
 			}
 		}
 	}

--- a/pkg/webhook/rollout/validating/rollout_create_update_handler.go
+++ b/pkg/webhook/rollout/validating/rollout_create_update_handler.go
@@ -243,8 +243,8 @@ func validateRolloutSpecCanarySteps(steps []appsv1alpha1.CanaryStep, fldPath *fi
 			if err != nil ||
 				canaryReplicas <= 0 ||
 				(canaryReplicas > 100 && s.Replicas.Type == intstr.String) {
-				return field.ErrorList{field.Invalid(fldPath.Index(i).Child("CanaryReplicas"),
-					s.Replicas, `canaryReplicas must be positive number, or a percentage with "0%" < canaryReplicas <= "100%"`)}
+				return field.ErrorList{field.Invalid(fldPath.Index(i).Child("Replicas"),
+					s.Replicas, `replicas must be positive number, or a percentage with "0%" < canaryReplicas <= "100%"`)}
 			}
 		}
 	}

--- a/pkg/webhook/rollout/validating/rollout_create_update_handler_test.go
+++ b/pkg/webhook/rollout/validating/rollout_create_update_handler_test.go
@@ -72,6 +72,12 @@ var (
 						{
 							Weight: utilpointer.Int32Ptr(100),
 						},
+						{
+							Weight: utilpointer.Int32Ptr(101),
+						},
+						{
+							Weight: utilpointer.Int32Ptr(200),
+						},
 					},
 					TrafficRoutings: []*appsv1alpha1.TrafficRouting{
 						{


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
When the data type of spec.replicas is int, cancel the upper limit.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

#141

### Ⅲ. Special notes for reviews
