### PR TITLE
Add DaemonSet e2e test

### DIFF
--- a/.github/workflows/e2e-daemonset-1.19.yaml
+++ b/.github/workflows/e2e-daemonset-1.19.yaml
@@ -1,0 +1,110 @@
+name: E2E-DaemonSet-1.19
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request: {}
+  workflow_dispatch: {}
+
+env:
+  # Common versions
+  GO_VERSION: '1.17'
+  KIND_IMAGE: 'kindest/node:v1.19.16'
+  KIND_CLUSTER_NAME: 'ci-testing'
+
+jobs:
+
+  rollout:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          node_image: ${{ env.KIND_IMAGE }}
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          config: ./test/kind-conf.yaml
+      - name: Build image
+        run: |
+          export IMAGE="openkruise/kruise-rollout:e2e-${GITHUB_RUN_ID}"
+          docker build --pull --no-cache . -t $IMAGE
+          kind load docker-image --name=${KIND_CLUSTER_NAME} $IMAGE || { echo >&2 "kind not installed or error loading image: $IMAGE"; exit 1; }
+      - name: Install Kruise
+        run: |
+          set -ex
+          kubectl cluster-info
+          make helm
+          helm repo add openkruise https://openkruise.github.io/charts/
+          helm repo update
+          helm install kruise openkruise/kruise
+          for ((i=1;i<10;i++));
+          do
+            set +e
+            PODS=$(kubectl get pod -n kruise-system | grep '1/1' | grep kruise-controller-manager | wc -l)
+            set -e
+            if [ "$PODS" -eq "2" ]; then
+              break
+            fi
+            sleep 3
+          done
+          set +e
+          PODS=$(kubectl get pod -n kruise-system | grep '1/1' | grep kruise-controller-manager | wc -l)
+          set -e
+          if [ "$PODS" -eq "2" ]; then
+            echo "Wait for kruise-manager ready successfully"
+          else
+            echo "Timeout to wait for kruise-manager ready"
+            exit 1
+          fi
+      - name: Install Kruise Rollout
+        run: |
+          set -ex
+          kubectl cluster-info
+          IMG=openkruise/kruise-rollout:e2e-${GITHUB_RUN_ID} ./scripts/deploy_kind.sh
+          for ((i=1;i<10;i++));
+          do
+            set +e
+            PODS=$(kubectl get pod -n kruise-rollout | grep '1/1' | wc -l)
+            set -e
+            if [ "$PODS" -eq "1" ]; then
+              break
+            fi
+            sleep 3
+          done
+          set +e
+          PODS=$(kubectl get pod -n kruise-rollout | grep '1/1' | wc -l)
+          kubectl get node -o yaml
+          kubectl get all -n kruise-rollout -o yaml
+          set -e
+          if [ "$PODS" -eq "1" ]; then
+            echo "Wait for kruise-rollout ready successfully"
+          else
+            echo "Timeout to wait for kruise-rollout ready"
+            exit 1
+          fi
+      - name: Run E2E Tests
+        run: |
+          export KUBECONFIG=/home/runner/.kube/config
+          make ginkgo
+          set +e
+          ./bin/ginkgo -timeout 60m -v --focus='DaemonSet canary rollout' test/e2e
+          retVal=$?
+          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
+          if [ "${restartCount}" -eq "0" ];then
+              echo "Kruise-rollout has not restarted"
+          else
+              kubectl get pod -n kruise-rollout --no-headers
+              echo "Kruise-rollout has restarted, abort!!!"
+              kubectl get pod -n kruise-rollout --no-headers| awk '{print $1}' | xargs kubectl logs -p -n kruise-rollout
+              exit 1
+          fi
+          exit $retVal

--- a/.github/workflows/e2e-daemonset-1.23.yaml
+++ b/.github/workflows/e2e-daemonset-1.23.yaml
@@ -1,0 +1,110 @@
+name: E2E-DaemonSet-1.23
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request: {}
+  workflow_dispatch: {}
+
+env:
+  # Common versions
+  GO_VERSION: '1.17'
+  KIND_IMAGE: 'kindest/node:v1.23.3'
+  KIND_CLUSTER_NAME: 'ci-testing'
+
+jobs:
+
+  rollout:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          node_image: ${{ env.KIND_IMAGE }}
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          config: ./test/kind-conf.yaml
+      - name: Build image
+        run: |
+          export IMAGE="openkruise/kruise-rollout:e2e-${GITHUB_RUN_ID}"
+          docker build --pull --no-cache . -t $IMAGE
+          kind load docker-image --name=${KIND_CLUSTER_NAME} $IMAGE || { echo >&2 "kind not installed or error loading image: $IMAGE"; exit 1; }
+      - name: Install Kruise
+        run: |
+          set -ex
+          kubectl cluster-info
+          make helm
+          helm repo add openkruise https://openkruise.github.io/charts/
+          helm repo update
+          helm install kruise openkruise/kruise
+          for ((i=1;i<10;i++));
+          do
+            set +e
+            PODS=$(kubectl get pod -n kruise-system | grep '1/1' | grep kruise-controller-manager | wc -l)
+            set -e
+            if [ "$PODS" -eq "2" ]; then
+              break
+            fi
+            sleep 3
+          done
+          set +e
+          PODS=$(kubectl get pod -n kruise-system | grep '1/1' | grep kruise-controller-manager | wc -l)
+          set -e
+          if [ "$PODS" -eq "2" ]; then
+            echo "Wait for kruise-manager ready successfully"
+          else
+            echo "Timeout to wait for kruise-manager ready"
+            exit 1
+          fi
+      - name: Install Kruise Rollout
+        run: |
+          set -ex
+          kubectl cluster-info
+          IMG=openkruise/kruise-rollout:e2e-${GITHUB_RUN_ID} ./scripts/deploy_kind.sh
+          for ((i=1;i<10;i++));
+          do
+            set +e
+            PODS=$(kubectl get pod -n kruise-rollout | grep '1/1' | wc -l)
+            set -e
+            if [ "$PODS" -eq "1" ]; then
+              break
+            fi
+            sleep 3
+          done
+          set +e
+          PODS=$(kubectl get pod -n kruise-rollout | grep '1/1' | wc -l)
+          kubectl get node -o yaml
+          kubectl get all -n kruise-rollout -o yaml
+          set -e
+          if [ "$PODS" -eq "1" ]; then
+            echo "Wait for kruise-rollout ready successfully"
+          else
+            echo "Timeout to wait for kruise-rollout ready"
+            exit 1
+          fi
+      - name: Run E2E Tests
+        run: |
+          export KUBECONFIG=/home/runner/.kube/config
+          make ginkgo
+          set +e
+          ./bin/ginkgo -timeout 60m -v --focus='DaemonSet canary rollout' test/e2e
+          retVal=$?
+          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
+          if [ "${restartCount}" -eq "0" ];then
+              echo "Kruise-rollout has not restarted"
+          else
+              kubectl get pod -n kruise-rollout --no-headers
+              echo "Kruise-rollout has restarted, abort!!!"
+              kubectl get pod -n kruise-rollout --no-headers| awk '{print $1}' | xargs kubectl logs -p -n kruise-rollout
+              exit 1
+          fi
+          exit $retVal

--- a/test/e2e/rollout_test.go
+++ b/test/e2e/rollout_test.go
@@ -5087,7 +5087,7 @@ var _ = SIGDescribe("Rollout", func() {
 			WaitDaemonSetAllPodsReady(workload)
 			By("rollout completed, and check")
 
-			// check deployment
+			// check daemonset
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
 			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
 			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
@@ -5226,7 +5226,7 @@ var _ = SIGDescribe("Rollout", func() {
 			WaitDaemonSetAllPodsReady(workload)
 			By("rollout completed, and check")
 
-			// check deployment
+			// check daemonset
 			// daemonset
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
 			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
@@ -5309,8 +5309,8 @@ var _ = SIGDescribe("Rollout", func() {
 			By("Update deployment paused=false")
 			WaitDaemonSetAllPodsReady(workload)
 
-			// check deployment
-			// deployment
+			// check daemonset
+			// daemonset
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
 			Expect(*workload.Spec.UpdateStrategy.RollingUpdate.Paused).Should(BeFalse())
 			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))

--- a/test/e2e/rollout_test.go
+++ b/test/e2e/rollout_test.go
@@ -121,6 +121,24 @@ var _ = SIGDescribe("Rollout", func() {
 		return clone
 	}
 
+	UpdateDaemonSet := func(object *appsv1alpha1.DaemonSet) *appsv1alpha1.DaemonSet {
+		var daemon *appsv1alpha1.DaemonSet
+		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			daemon = &appsv1alpha1.DaemonSet{}
+			err := GetObject(object.Name, daemon)
+			if err != nil {
+				return err
+			}
+			// daemon.Spec.Replicas = utilpointer.Int32(*object.Spec.Replicas)
+			daemon.Spec.Template = *object.Spec.Template.DeepCopy()
+			daemon.Labels = mergeMap(daemon.Labels, object.Labels)
+			daemon.Annotations = mergeMap(daemon.Annotations, object.Annotations)
+			return k8sClient.Update(context.TODO(), daemon)
+		})).NotTo(HaveOccurred())
+
+		return daemon
+	}
+
 	UpdateNativeStatefulSet := func(object *apps.StatefulSet) *apps.StatefulSet {
 		var clone *apps.StatefulSet
 		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -221,6 +239,14 @@ var _ = SIGDescribe("Rollout", func() {
 			return set.Status.ObservedGeneration == set.Generation && *set.Spec.Replicas == set.Status.UpdatedReplicas &&
 				*set.Spec.Replicas == set.Status.ReadyReplicas && *set.Spec.Replicas == set.Status.Replicas
 		}, 20*time.Minute, 3*time.Second).Should(BeTrue())
+	}
+
+	WaitDaemonSetAllPodsReady := func(daemonset *appsv1alpha1.DaemonSet) {
+		Eventually(func() bool {
+			daemon := &appsv1alpha1.DaemonSet{}
+			Expect(GetObject(daemonset.Name, daemon)).NotTo(HaveOccurred())
+			return daemon.Status.ObservedGeneration == daemon.Generation && daemon.Status.DesiredNumberScheduled == daemon.Status.UpdatedNumberScheduled && daemon.Status.DesiredNumberScheduled == daemon.Status.NumberReady
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	}
 
 	WaitDeploymentReplicas := func(deployment *apps.Deployment) {
@@ -4992,6 +5018,311 @@ var _ = SIGDescribe("Rollout", func() {
 			ResumeRolloutCanary(rollout.Name)
 			WaitDeploymentAllPodsReady(workload)
 		})
+	})
+
+	KruiseDescribe("DaemonSet canary rollout", func() {
+		It("DaemonSet V1->V2: 1,100% Succeeded", func() {
+			By("Creating Rollout...")
+			rollout := &v1alpha1.Rollout{}
+			Expect(ReadYamlToObject("./test_data/rollout/rollout_canary_daemonset_base.yaml", rollout)).ToNot(HaveOccurred())
+			rollout.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{
+				{
+					Replicas: &intstr.IntOrString{IntVal: int32(*utilpointer.Int32(1)), Type: intstr.Int},
+					Pause:    v1alpha1.RolloutPause{},
+				},
+				{
+					Replicas: &intstr.IntOrString{IntVal: int32(*utilpointer.Int32Ptr(100)), Type: intstr.Int},
+					Pause:    v1alpha1.RolloutPause{},
+				},
+			}
+			rollout.Spec.ObjectRef.WorkloadRef = &v1alpha1.WorkloadRef{
+				APIVersion: "apps.kruise.io/v1alpha1",
+				Kind:       "DaemonSet",
+				Name:       "fluentd-elasticsearch",
+			}
+			CreateObject(rollout)
+
+			By("Creating workload and waiting for all pods ready...")
+			// workload
+			workload := &appsv1alpha1.DaemonSet{}
+			Expect(ReadYamlToObject("./test_data/rollout/daemonset.yaml", workload)).ToNot(HaveOccurred())
+			CreateObject(workload)
+			WaitDaemonSetAllPodsReady(workload)
+
+			// check rollout status
+			By("check rollout status & paused success")
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(rollout.Status.Phase).Should(Equal(v1alpha1.RolloutPhaseHealthy))
+
+			// v1 -> v2, start rollout action
+			By("Update daemonset env NODE_NAME from(version1) -> to(version2)")
+			newEnvs := mergeEnvVar(workload.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{Name: "NODE_NAME", Value: "version2"})
+			workload.Spec.Template.Spec.Containers[0].Env = newEnvs
+			UpdateDaemonSet(workload)
+			// wait step 1 complete
+			WaitRolloutCanaryStepPaused(rollout.Name, 1)
+
+			// check workload status & paused
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", 1))
+			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(*workload.Spec.UpdateStrategy.RollingUpdate.Paused).Should(BeFalse())
+			By("check daemonset status & paused success")
+
+			// check rollout status
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			Expect(rollout.Status.Phase).Should(Equal(v1alpha1.RolloutPhaseProgressing))
+			Expect(rollout.Status.CanaryStatus.CurrentStepIndex).Should(BeNumerically("==", 1))
+			Expect(rollout.Status.CanaryStatus.RolloutHash).Should(Equal(rollout.Annotations[util.RolloutHashAnnotation]))
+
+			// resume rollout canary
+			ResumeRolloutCanary(rollout.Name)
+			By("resume rollout, and wait next step(2)")
+			WaitRolloutCanaryStepPaused(rollout.Name, 2)
+
+			// resume rollout
+			ResumeRolloutCanary(rollout.Name)
+			WaitRolloutStatusPhase(rollout.Name, v1alpha1.RolloutPhaseHealthy)
+			WaitDaemonSetAllPodsReady(workload)
+			By("rollout completed, and check")
+
+			// check deployment
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			for _, env := range workload.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "NODE_NAME" {
+					Expect(env.Value).Should(Equal("version2"))
+				}
+			}
+			time.Sleep(time.Second * 3)
+
+			// check progressing succeed
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			cond := util.GetRolloutCondition(rollout.Status, v1alpha1.RolloutConditionProgressing)
+			Expect(cond.Reason).Should(Equal(v1alpha1.ProgressingReasonCompleted))
+			Expect(string(cond.Status)).Should(Equal(string(metav1.ConditionFalse)))
+			cond = util.GetRolloutCondition(rollout.Status, v1alpha1.RolloutConditionSucceeded)
+			Expect(string(cond.Status)).Should(Equal(string(metav1.ConditionTrue)))
+			WaitRolloutWorkloadGeneration(rollout.Name, workload.Generation)
+
+		})
+
+		It("V1->V2: Percentage, 1, 2 and continuous release v3", func() {
+			By("Creating Rollout...")
+			rollout := &v1alpha1.Rollout{}
+			Expect(ReadYamlToObject("./test_data/rollout/rollout_canary_daemonset_interrupt.yaml", rollout)).ToNot(HaveOccurred())
+			rollout.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{
+				{
+					Replicas: &intstr.IntOrString{IntVal: int32(*utilpointer.Int32(1)), Type: intstr.Int},
+					Pause:    v1alpha1.RolloutPause{},
+				},
+				{
+					Replicas: &intstr.IntOrString{IntVal: int32(*utilpointer.Int32Ptr(2)), Type: intstr.Int},
+					Pause:    v1alpha1.RolloutPause{},
+				},
+				{
+					Replicas: &intstr.IntOrString{IntVal: int32(*utilpointer.Int32Ptr(100)), Type: intstr.Int},
+					Pause:    v1alpha1.RolloutPause{},
+				},
+			}
+			rollout.Spec.ObjectRef.WorkloadRef = &v1alpha1.WorkloadRef{
+				APIVersion: "apps.kruise.io/v1alpha1",
+				Kind:       "DaemonSet",
+				Name:       "fluentd-elasticsearch",
+			}
+			CreateObject(rollout)
+
+			By("Creating workload and waiting for all pods ready...")
+			// workload
+			workload := &appsv1alpha1.DaemonSet{}
+			Expect(ReadYamlToObject("./test_data/rollout/daemonset.yaml", workload)).ToNot(HaveOccurred())
+			CreateObject(workload)
+			WaitDaemonSetAllPodsReady(workload)
+
+			// check rollout status
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(rollout.Status.Phase).Should(Equal(v1alpha1.RolloutPhaseHealthy))
+			By("check rollout status & paused success")
+
+			// v1 -> v2, start rollout action
+			newEnvs := mergeEnvVar(workload.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{Name: "NODE_NAME", Value: "version2"})
+			workload.Spec.Template.Spec.Containers[0].Env = newEnvs
+			UpdateDaemonSet(workload)
+			By("Update daemonSet env NODE_NAME from(version1) -> to(version2)")
+			// wait step 1 complete
+			WaitRolloutCanaryStepPaused(rollout.Name, 1)
+
+			// check workload status & paused
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", 1))
+			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(*workload.Spec.UpdateStrategy.RollingUpdate.Paused).Should(BeFalse())
+			By("check daemonSet status & paused success")
+
+			// check rollout status
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(rollout.Status.Phase).Should(Equal(v1alpha1.RolloutPhaseProgressing))
+			Expect(rollout.Status.CanaryStatus.CurrentStepIndex).Should(BeNumerically("==", 1))
+			Expect(rollout.Status.CanaryStatus.RolloutHash).Should(Equal(rollout.Annotations[util.RolloutHashAnnotation]))
+
+			// resume rollout canary
+			ResumeRolloutCanary(rollout.Name)
+			By("resume rollout, and wait next step(2)")
+			WaitRolloutCanaryStepPaused(rollout.Name, 2)
+
+			// v1 -> v2 -> v3, continuous release
+			By("Update daemonSet env NODE_NAME from(version2) -> to(version3)")
+			newEnvs = mergeEnvVar(workload.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{Name: "NODE_NAME", Value: "version3"})
+			workload.Spec.Template.Spec.Containers[0].Env = newEnvs
+			UpdateDaemonSet(workload)
+
+			// wait step 1 complete
+			WaitRolloutCanaryStepPaused(rollout.Name, 1)
+
+			// check workload status & paused
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", 1))
+			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(*workload.Spec.UpdateStrategy.RollingUpdate.Paused).Should(BeFalse())
+			By("check daemonSet status & paused success")
+
+			// check rollout status
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(rollout.Status.Phase).Should(Equal(v1alpha1.RolloutPhaseProgressing))
+			Expect(rollout.Status.CanaryStatus.CurrentStepIndex).Should(BeNumerically("==", 1))
+
+			// resume rollout canary
+			ResumeRolloutCanary(rollout.Name)
+			By("resume rollout, and wait next step(2)")
+			WaitRolloutCanaryStepPaused(rollout.Name, 2)
+
+			// check workload status & paused
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", 2))
+			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(*workload.Spec.UpdateStrategy.RollingUpdate.Paused).Should(BeFalse())
+			By("check daemonSet status & paused success")
+
+			// check rollout status
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(rollout.Status.Phase).Should(Equal(v1alpha1.RolloutPhaseProgressing))
+			Expect(rollout.Status.CanaryStatus.CurrentStepIndex).Should(BeNumerically("==", 2))
+
+			// resume rollout canary
+			ResumeRolloutCanary(rollout.Name)
+			By("resume rollout, and wait next step(3)")
+			WaitRolloutCanaryStepPaused(rollout.Name, 3)
+
+			// resume rollout
+			ResumeRolloutCanary(rollout.Name)
+			WaitRolloutStatusPhase(rollout.Name, v1alpha1.RolloutPhaseHealthy)
+			WaitDaemonSetAllPodsReady(workload)
+			By("rollout completed, and check")
+
+			// check deployment
+			// daemonset
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			for _, env := range workload.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "NODE_NAME" {
+					Expect(env.Value).Should(Equal("version3"))
+				}
+			}
+			time.Sleep(time.Second * 3)
+
+			// check progressing succeed
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			cond := util.GetRolloutCondition(rollout.Status, v1alpha1.RolloutConditionProgressing)
+			Expect(cond.Reason).Should(Equal(v1alpha1.ProgressingReasonCompleted))
+			Expect(string(cond.Status)).Should(Equal(string(metav1.ConditionFalse)))
+			cond = util.GetRolloutCondition(rollout.Status, v1alpha1.RolloutConditionSucceeded)
+			Expect(string(cond.Status)).Should(Equal(string(metav1.ConditionTrue)))
+			WaitRolloutWorkloadGeneration(rollout.Name, workload.Generation)
+		})
+
+		It("V1->V2: 1,100%, but delete rollout crd", func() {
+			// finder := util.NewControllerFinder(k8sClient)
+			By("Creating Rollout...")
+			rollout := &v1alpha1.Rollout{}
+			Expect(ReadYamlToObject("./test_data/rollout/rollout_canary_daemonset_base.yaml", rollout)).ToNot(HaveOccurred())
+			rollout.Spec.Strategy.Canary.Steps = []v1alpha1.CanaryStep{
+				{
+					Replicas: &intstr.IntOrString{IntVal: int32(*utilpointer.Int32(1)), Type: intstr.Int},
+					Pause:    v1alpha1.RolloutPause{},
+				},
+				{
+					Replicas: &intstr.IntOrString{IntVal: int32(*utilpointer.Int32Ptr(100)), Type: intstr.Int},
+					Pause:    v1alpha1.RolloutPause{},
+				},
+			}
+			rollout.Spec.ObjectRef.WorkloadRef = &v1alpha1.WorkloadRef{
+				APIVersion: "apps.kruise.io/v1alpha1",
+				Kind:       "DaemonSet",
+				Name:       "fluentd-elasticsearch",
+			}
+			CreateObject(rollout)
+			By("Creating workload and waiting for all pods ready...")
+
+			// workload
+			workload := &appsv1alpha1.DaemonSet{}
+			Expect(ReadYamlToObject("./test_data/rollout/daemonset.yaml", workload)).ToNot(HaveOccurred())
+			CreateObject(workload)
+			WaitDaemonSetAllPodsReady(workload)
+
+			// check rollout status
+			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(rollout.Status.Phase).Should(Equal(v1alpha1.RolloutPhaseHealthy))
+			By("check rollout status & paused success")
+
+			// v1 -> v2, start rollout action
+			By("Update deployment env NODE_NAME from(version1) -> to(version2)")
+			newEnvs := mergeEnvVar(workload.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{Name: "NODE_NAME", Value: "version2"})
+			workload.Spec.Template.Spec.Containers[0].Env = newEnvs
+			UpdateDaemonSet(workload)
+			WaitRolloutCanaryStepPaused(rollout.Name, 1)
+			time.Sleep(time.Second * 3)
+
+			// check workload status & paused
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", 1))
+			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(*workload.Spec.UpdateStrategy.RollingUpdate.Paused).Should(BeFalse())
+			By("check deployment status & paused success")
+
+			// delete rollout
+			Expect(k8sClient.DeleteAllOf(context.TODO(), &v1alpha1.Rollout{}, client.InNamespace(namespace), client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(Succeed())
+			WaitRolloutNotFound(rollout.Name)
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			fmt.Println(util.DumpJSON(workload))
+			workload.Spec.UpdateStrategy.RollingUpdate.Paused = utilpointer.Bool(false)
+			UpdateDaemonSet(workload)
+			By("Update deployment paused=false")
+			WaitDaemonSetAllPodsReady(workload)
+
+			// check deployment
+			// deployment
+			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			Expect(*workload.Spec.UpdateStrategy.RollingUpdate.Paused).Should(BeFalse())
+			Expect(workload.Status.UpdatedNumberScheduled).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(workload.Status.NumberReady).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			Expect(workload.Status.CurrentNumberScheduled).Should(BeNumerically("==", workload.Status.DesiredNumberScheduled))
+			for _, env := range workload.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "NODE_NAME" {
+					Expect(env.Value).Should(Equal("version2"))
+				}
+			}
+		})
+
 	})
 })
 

--- a/test/e2e/test_data/rollout/daemonset.yaml
+++ b/test/e2e/test_data/rollout/daemonset.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps.kruise.io/v1alpha1
+kind: DaemonSet
+metadata:
+  name: fluentd-elasticsearch
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+spec:
+  selector:
+    matchLabels:
+      name: fluentd-elasticsearch
+  template:
+    metadata:
+      labels:
+        name: fluentd-elasticsearch
+    spec:
+      tolerations:
+      # these tolerations are to have the daemonset runnable on control plane nodes
+      # remove them if your control plane nodes should not run pods
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: fluentd-elasticsearch
+        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      # updateStrategy:
+      #   type: RollingUpdate
+      #   rollingUpdate:
+      #     rollingUpdateType: Standard

--- a/test/e2e/test_data/rollout/rollout_canary_daemonset_base.yaml
+++ b/test/e2e/test_data/rollout/rollout_canary_daemonset_base.yaml
@@ -1,0 +1,21 @@
+apiVersion: rollouts.kruise.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-test
+  # The rollout resource needs to be in the same namespace as the corresponding workload
+  namespace: kube-system
+  # This annotation can help us upgrade the Deployment using partition, just like StatefulSet/CloneSet.
+  annotations:
+    rollouts.kruise.io/rolling-style: partition
+spec:
+  objectRef:
+    # rollout of published workloads, currently only supports Deployment, CloneSet, StatefulSet, Advanced StatefulSet
+    workloadRef:
+      apiVersion: apps.kruise.io/v1alpha1
+      kind: DaemonSet
+      name: fluentd-elasticsearch
+  strategy:
+    canary:
+      steps:
+      - replicas: 1
+      - replicas: 100%

--- a/test/e2e/test_data/rollout/rollout_canary_daemonset_interrupt.yaml
+++ b/test/e2e/test_data/rollout/rollout_canary_daemonset_interrupt.yaml
@@ -1,0 +1,22 @@
+apiVersion: rollouts.kruise.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-test
+  # The rollout resource needs to be in the same namespace as the corresponding workload
+  namespace: kube-system
+  # This annotation can help us upgrade the Deployment using partition, just like StatefulSet/CloneSet.
+  annotations:
+    rollouts.kruise.io/rolling-style: partition
+spec:
+  objectRef:
+    # rollout of published workloads, currently only supports Deployment, CloneSet, StatefulSet, Advanced StatefulSet
+    workloadRef:
+      apiVersion: apps.kruise.io/v1alpha1
+      kind: DaemonSet
+      name: fluentd-elasticsearch
+  strategy:
+    canary:
+      steps:
+      - replicas: 1
+      - replicas: 2
+      - replicas: 100%


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Description
Add DaemonSet e2e tests including 3 cases:
1) Normal rollout update:
   "DaemonSet V1->V2: 1,100% Succeeded"

2) v1 -> v2(interrupt) -> v3
   "V1->V2: Percentage, 1, 2 and continuous release v3"

3) delete rollout during the process
   "V1->V2: 1,100%, but delete rollout crd"

### Ⅱ. Test Process
1) Set up basic environment according to this md:
    https://github.com/openkruise/rollouts/blob/master/docs/contributing/debug.md

2) run kubectl apply -f rollout_canary_daemonset_base.yaml, and rollout_canary_daemonset_base.yaml is under the path:
     test/e2e/test_data/rollout/rollout_canary_daemonset_base.yaml

3) run kubectl apply -f rollout_canary_daemonset_interrupt.yaml, and rollout_canary_daemonset_interrupt.yaml is under the path:
    test/e2e/test_data/rollout/rollout_canary_daemonset_interrupt.yaml

4) run ginkgo -timeout 60m -v --focus="DaemonSet canary rollout" test/e2e under rollouts package.
### Ⅲ. Test Result
All three cases passed
1) 
<img width="1923" alt="Screen Shot 2023-04-27 at 17 06 32" src="https://user-images.githubusercontent.com/95588190/235069449-e20454dd-7a13-4dad-ac0c-b681e33c30a4.png">
2)
<img width="1984" alt="Screen Shot 2023-04-27 at 17 07 32" src="https://user-images.githubusercontent.com/95588190/235069486-32e0771a-0906-4731-aaa6-4dca1bc292ac.png">
3) 
<img width="1893" alt="Screen Shot 2023-04-27 at 17 16 35" src="https://user-images.githubusercontent.com/95588190/235069499-040ee8b6-d2fa-41ba-8759-77b0931f706a.png">
