### PR TITLE
Add disabled field in rollout spec

### DIFF
--- a/api/v1alpha1/rollout_types.go
+++ b/api/v1alpha1/rollout_types.go
@@ -72,6 +72,10 @@ type RolloutSpec struct {
 	// RolloutID should be changed before each workload revision publication.
 	// It is to distinguish consecutive multiple workload publications and rollout progress.
 	DeprecatedRolloutID string `json:"rolloutID,omitempty"`
+	// if a rollout disabled, then the rollout would not watch changes of workload
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default=false
+	Disabled bool `json:"disabled"`
 }
 
 type ObjectRef struct {
@@ -257,6 +261,10 @@ const (
 	RolloutPhaseProgressing RolloutPhase = "Progressing"
 	// RolloutPhaseTerminating indicates a rollout is terminated
 	RolloutPhaseTerminating RolloutPhase = "Terminating"
+	// RolloutPhaseDisabled indicates a rollout is disabled
+	RolloutPhaseDisabled RolloutPhase = "Disabled"
+	// RolloutPhaseDisabling indicates a rollout is disabling and releasing resources
+	RolloutPhaseDisabling RolloutPhase = "Disabling"
 )
 
 // +genclient

--- a/config/crd/bases/rollouts.kruise.io_rollouts.yaml
+++ b/config/crd/bases/rollouts.kruise.io_rollouts.yaml
@@ -56,6 +56,11 @@ spec:
           spec:
             description: RolloutSpec defines the desired state of Rollout
             properties:
+              disabled:
+                default: false
+                description: if a rollout disabled, then the rollout would not watch
+                  changes of workload
+                type: boolean
               objectRef:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "make" to regenerate code after modifying this file

--- a/pkg/controller/rollout/rollout_controller.go
+++ b/pkg/controller/rollout/rollout_controller.go
@@ -130,6 +130,7 @@ func (r *RolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
 	// sync rollout status
 	retry, newStatus, err := r.calculateRolloutStatus(rollout)
 	if err != nil {
@@ -139,11 +140,14 @@ func (r *RolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{RequeueAfter: time.Until(recheckTime)}, nil
 	}
 	var recheckTime *time.Time
+
 	switch rollout.Status.Phase {
 	case v1alpha1.RolloutPhaseProgressing:
 		recheckTime, err = r.reconcileRolloutProgressing(rollout, newStatus)
 	case v1alpha1.RolloutPhaseTerminating:
 		recheckTime, err = r.reconcileRolloutTerminating(rollout, newStatus)
+	case v1alpha1.RolloutPhaseDisabling:
+		recheckTime, err = r.reconcileRolloutDisabling(rollout, newStatus)
 	}
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/webhook/rollout/validating/rollout_create_update_handler_test.go
+++ b/pkg/webhook/rollout/validating/rollout_create_update_handler_test.go
@@ -333,6 +333,7 @@ func TestRolloutValidateCreate(t *testing.T) {
 				object3 := rollout.DeepCopy()
 				object3.Name = "object-3"
 				object3.Spec.ObjectRef.WorkloadRef.Kind = "another"
+
 				return []client.Object{
 					object, object1, object2, object3,
 				}

--- a/pkg/webhook/workload/mutating/workload_update_handler.go
+++ b/pkg/webhook/workload/mutating/workload_update_handler.go
@@ -409,6 +409,10 @@ func (h *WorkloadHandler) fetchMatchedRollout(obj client.Object) (*appsv1alpha1.
 		if !rollout.DeletionTimestamp.IsZero() || rollout.Spec.ObjectRef.WorkloadRef == nil {
 			continue
 		}
+		if rollout.Status.Phase == appsv1alpha1.RolloutPhaseDisabled {
+			klog.Infof("Disabled rollout(%s/%s) fetched when fetching matched rollout", rollout.Namespace, rollout.Name)
+			continue
+		}
 		ref := rollout.Spec.ObjectRef.WorkloadRef
 		gv, err := schema.ParseGroupVersion(ref.APIVersion)
 		if err != nil {

--- a/test/e2e/test_data/rollout/deployment_disabled.yaml
+++ b/test/e2e/test_data/rollout/deployment_disabled.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workload-demo
+  namespace: default
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+      - name: busybox
+        image: busybox:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 100d"]
+        env:
+        - name: VERSION
+          value: "version-1"

--- a/test/e2e/test_data/rollout/rollout_disabled.yaml
+++ b/test/e2e/test_data/rollout/rollout_disabled.yaml
@@ -1,0 +1,19 @@
+apiVersion: rollouts.kruise.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+  namespace: default
+  annotations:
+    rollouts.kruise.io/rolling-style: partition
+spec:
+  disabled: false
+  objectRef:
+    workloadRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: workload-demo
+  strategy:
+    canary:
+      steps:
+      - replicas: 2
+      - replicas: 50%


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
**Added `Disabled` field in rollout spec.**
**Added a rollout phase constant.**
```
// RolloutPhaseDisabled indicates a rollout is disabled
RolloutPhaseDisabled RolloutPhase = "Disabled"
```

#### How the Disabled spec works?
- If a rollout is disabled, the rollout is not working.
- When an rolling rollout is disabled, release the resources of the rollout and set its phase as `Disabled`.

### Ⅱ. Does this pull request fix one issue?
fixes #151 

### Ⅲ. Special notes for reviews
