### PR TITLE
auto patch webhook objectSelector label on workload

### DIFF
--- a/config/webhook/patch_manifests.yaml
+++ b/config/webhook/patch_manifests.yaml
@@ -8,6 +8,26 @@ webhooks:
       matchExpressions:
         - key: rollouts.kruise.io/workload-type
           operator: Exists
+  - name: mcloneset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+  - name: mdaemonset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+  - name: mstatefulset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
+  - name: madvancedstatefulset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists
   - name: mdeployment.kb.io
     objectSelector:
       matchExpressions:
@@ -15,3 +35,5 @@ webhooks:
           operator: NotIn
           values:
             - controller-manager
+        - key: rollouts.kruise.io/workload-type
+          operator: Exists

--- a/pkg/controller/rollout/rollout_controller.go
+++ b/pkg/controller/rollout/rollout_controller.go
@@ -130,7 +130,11 @@ func (r *RolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-
+	// Patch rollout webhook objectSelector in workload labels[rollouts.kruise.io/workload-type],
+	// then rollout only webhook the workload which contains labels[rollouts.kruise.io/workload-type].
+	if err = r.patchWorkloadRolloutWebhookLabel(rollout); err != nil {
+		return ctrl.Result{}, err
+	}
 	// sync rollout status
 	retry, newStatus, err := r.calculateRolloutStatus(rollout)
 	if err != nil {

--- a/test/e2e/rollout_test.go
+++ b/test/e2e/rollout_test.go
@@ -245,8 +245,8 @@ var _ = SIGDescribe("Rollout", func() {
 		Eventually(func() bool {
 			daemon := &appsv1alpha1.DaemonSet{}
 			Expect(GetObject(daemonset.Name, daemon)).NotTo(HaveOccurred())
-			klog.Infof("DaemonSet Generation(%d) ObservedGeneration(%d) DesiredNumberScheduled(%d) UpdatedNumberScheduled(%d) NumberReady(%d)",
-				daemon.Generation, daemon.Status.ObservedGeneration, daemon.Status.DesiredNumberScheduled, daemon.Status.UpdatedNumberScheduled, daemon.Status.NumberReady)
+			klog.Infof("DaemonSet updateStrategy(%s) Generation(%d) ObservedGeneration(%d) DesiredNumberScheduled(%d) UpdatedNumberScheduled(%d) NumberReady(%d)",
+				util.DumpJSON(daemon.Spec.UpdateStrategy), daemon.Generation, daemon.Status.ObservedGeneration, daemon.Status.DesiredNumberScheduled, daemon.Status.UpdatedNumberScheduled, daemon.Status.NumberReady)
 			return daemon.Status.ObservedGeneration == daemon.Generation && daemon.Status.DesiredNumberScheduled == daemon.Status.UpdatedNumberScheduled && daemon.Status.DesiredNumberScheduled == daemon.Status.NumberReady
 		}, 5*time.Minute, time.Second).Should(BeTrue())
 	}
@@ -5468,6 +5468,8 @@ var _ = SIGDescribe("Rollout", func() {
 			Expect(k8sClient.DeleteAllOf(context.TODO(), &v1alpha1.Rollout{}, client.InNamespace(namespace), client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(Succeed())
 			WaitRolloutNotFound(rollout.Name)
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+			workload.Spec.UpdateStrategy.RollingUpdate.Partition = utilpointer.Int32(0)
+			UpdateDaemonSet(workload)
 			WaitDaemonSetAllPodsReady(workload)
 
 			// check daemonset


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
**Rollout patch webhook label on workload**

Currently rollout will webhook all workloads update requests, include Deployment, StatefulSet, CloneSet, Advanced StatefulSet. But not all workloads have to be rollout released, and if kruise rollout crashes will lead to workload update failed. So we can add configuration in MutatingWebhookConfiguration yaml.

```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
...
  objectSelector:
      matchExpressions:
        - key: rollouts.kruise.io/workload-type
          operator: Exists
```

And the rollout controller patches the above label to the workload according to the Rollout objectRef.