### PR TITLE
optimize webhook patchResponse function

### DIFF
--- a/pkg/webhook/workload/mutating/workload_update_handler.go
+++ b/pkg/webhook/workload/mutating/workload_update_handler.go
@@ -99,48 +99,58 @@ func (h *WorkloadHandler) Handle(ctx context.Context, req admission.Request) adm
 			if err := h.Decoder.Decode(req, newObj); err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
+			newObjClone := newObj.DeepCopy()
 			oldObj := &kruiseappsv1alpha1.CloneSet{}
 			if err := h.Decoder.Decode(
 				admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Object: req.AdmissionRequest.OldObject}},
 				oldObj); err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
-			changed, err := h.handleCloneSet(newObj, oldObj)
+			changed, err := h.handleCloneSet(newObjClone, oldObj)
 			if err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
 			if !changed {
 				return admission.Allowed("")
 			}
-			marshalled, err := json.Marshal(newObj)
+			marshalled, err := json.Marshal(newObjClone)
 			if err != nil {
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
-			return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
+			original, err := json.Marshal(newObj)
+			if err != nil {
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+			return admission.PatchResponseFromRaw(original, marshalled)
 		case util.ControllerKruiseKindDS.Kind:
 			// check daemonset
 			newObj := &kruiseappsv1alpha1.DaemonSet{}
 			if err := h.Decoder.Decode(req, newObj); err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
+			newObjClone := newObj.DeepCopy()
 			oldObj := &kruiseappsv1alpha1.DaemonSet{}
 			if err := h.Decoder.Decode(
 				admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Object: req.AdmissionRequest.OldObject}},
 				oldObj); err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
-			changed, err := h.handleDaemonSet(newObj, oldObj)
+			changed, err := h.handleDaemonSet(newObjClone, oldObj)
 			if err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
 			if !changed {
 				return admission.Allowed("")
 			}
-			marshalled, err := json.Marshal(newObj)
+			marshalled, err := json.Marshal(newObjClone)
 			if err != nil {
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
-			return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
+			original, err := json.Marshal(newObj)
+			if err != nil {
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+			return admission.PatchResponseFromRaw(original, marshalled)
 		}
 
 	// native k8s deloyment
@@ -152,24 +162,29 @@ func (h *WorkloadHandler) Handle(ctx context.Context, req admission.Request) adm
 			if err := h.Decoder.Decode(req, newObj); err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
+			newObjClone := newObj.DeepCopy()
 			oldObj := &apps.Deployment{}
 			if err := h.Decoder.Decode(
 				admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Object: req.AdmissionRequest.OldObject}},
 				oldObj); err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
-			changed, err := h.handleDeployment(newObj, oldObj)
+			changed, err := h.handleDeployment(newObjClone, oldObj)
 			if err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
 			if !changed {
 				return admission.Allowed("")
 			}
-			marshalled, err := json.Marshal(newObj)
+			marshalled, err := json.Marshal(newObjClone)
 			if err != nil {
 				return admission.Errored(http.StatusInternalServerError, err)
 			}
-			return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
+			original, err := json.Marshal(newObj)
+			if err != nil {
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+			return admission.PatchResponseFromRaw(original, marshalled)
 		}
 	}
 

--- a/test/e2e/rollout_test.go
+++ b/test/e2e/rollout_test.go
@@ -131,6 +131,7 @@ var _ = SIGDescribe("Rollout", func() {
 			}
 			// daemon.Spec.Replicas = utilpointer.Int32(*object.Spec.Replicas)
 			daemon.Spec.Template = *object.Spec.Template.DeepCopy()
+			daemon.Spec.UpdateStrategy = *object.Spec.UpdateStrategy.DeepCopy()
 			daemon.Labels = mergeMap(daemon.Labels, object.Labels)
 			daemon.Annotations = mergeMap(daemon.Annotations, object.Annotations)
 			return k8sClient.Update(context.TODO(), daemon)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
There is a risk that the current webhook patch method will cause some fields to be lost if the rollout references a low version of the api. For example, k8s 1.26 adds a new field topologySpreadConstraint.minDomains, the field will be lost after the webhook.