### PR TITLE
fix: lua encode structural error

### DIFF
--- a/pkg/util/luamanager/json.go
+++ b/pkg/util/luamanager/json.go
@@ -108,7 +108,7 @@ func (j jsonValue) MarshalJSON() (data []byte, err error) {
 
 		switch key.Type() {
 		case lua.LTNil: // empty table
-			data = []byte(`[]`)
+			data = []byte(`null`)
 		case lua.LTNumber:
 			arr := make([]jsonValue, 0, converted.Len())
 			expectedKey := lua.LNumber(1)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
```
Pass an object to lua for modification, and the resulting return value. After serialization the field type changed.  
```
```
if not fix, the jsonBytes whill be 

 {"metadata":[],"spec":{"containers":[{"image":"centos:7","name":"centos","resources":[]}]},"status":[]}
```
- metadata
- status
- resources

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Special notes for reviews
