### PR TITLE
generate istio destinationRule subset from pod-template-hash 

### DIFF
--- a/api/v1alpha1/conversion.go
+++ b/api/v1alpha1/conversion.go
@@ -126,6 +126,7 @@ func (src *Rollout) ConvertTo(dst conversion.Hub) error {
 func ConversionToV1beta1TrafficRoutingRef(src TrafficRoutingRef) (dst v1beta1.TrafficRoutingRef) {
 	dst.Service = src.Service
 	dst.GracePeriodSeconds = src.GracePeriodSeconds
+	dst.AdditionalParams = src.AdditionalParams
 	if src.Ingress != nil {
 		dst.Ingress = &v1beta1.IngressTrafficRouting{
 			ClassType: src.Ingress.ClassType,

--- a/api/v1alpha1/trafficrouting_types.go
+++ b/api/v1alpha1/trafficrouting_types.go
@@ -23,6 +23,8 @@ import (
 
 const (
 	ProgressingRolloutFinalizerPrefix = "progressing.rollouts.kruise.io"
+	IstioStableSubsetName             = "istio.destinationRule.stableSubsetName"
+	IstioCanarySubsetName             = "istio.destinationRule.canarySubsetName"
 )
 
 // TrafficRoutingRef hosts all the different configuration for supported service meshes to enable more fine-grained traffic routing
@@ -38,6 +40,10 @@ type TrafficRoutingRef struct {
 	Gateway *GatewayTrafficRouting `json:"gateway,omitempty"`
 	// CustomNetworkRefs hold a list of custom providers to route traffic
 	CustomNetworkRefs []CustomNetworkRef `json:"customNetworkRefs,omitempty"`
+	// vaild keys:
+	// + IstioStableSubsetName
+	// + IstioCanarySubsetName
+	AdditionalParams map[string]string `json:"additionalParams,omitempty"`
 }
 
 // IngressTrafficRouting configuration for ingress controller to control traffic routing

--- a/api/v1beta1/trafficrouting.go
+++ b/api/v1beta1/trafficrouting.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package v1beta1
 
+const (
+	IstioStableSubsetName = "istio.destinationRule.stableSubsetName"
+	IstioCanarySubsetName = "istio.destinationRule.canarySubsetName"
+)
+
 // TrafficRoutingRef hosts all the different configuration for supported service meshes to enable more fine-grained traffic routing
 type TrafficRoutingRef struct {
 	// Service holds the name of a service which selects pods with stable version and don't select any pods with canary version.
@@ -29,6 +34,10 @@ type TrafficRoutingRef struct {
 	Gateway *GatewayTrafficRouting `json:"gateway,omitempty"`
 	// CustomNetworkRefs hold a list of custom providers to route traffic
 	CustomNetworkRefs []ObjectRef `json:"customNetworkRefs,omitempty"`
+	// vaild keys:
+	// + IstioStableSubsetName
+	// + IstioCanarySubsetName
+	AdditionalParams map[string]string `json:"additionalParams,omitempty"`
 }
 
 // IngressTrafficRouting configuration for ingress controller to control traffic routing

--- a/config/crd/bases/rollouts.kruise.io_rollouts.yaml
+++ b/config/crd/bases/rollouts.kruise.io_rollouts.yaml
@@ -344,6 +344,11 @@ spec:
                             for supported service meshes to enable more fine-grained
                             traffic routing
                           properties:
+                            additionalParams:
+                              additionalProperties:
+                                type: string
+                              description: 'vaild keys:'
+                              type: object
                             customNetworkRefs:
                               description: CustomNetworkRefs hold a list of custom
                                 providers to route traffic
@@ -834,6 +839,11 @@ spec:
                             for supported service meshes to enable more fine-grained
                             traffic routing
                           properties:
+                            additionalParams:
+                              additionalProperties:
+                                type: string
+                              description: 'vaild keys:'
+                              type: object
                             customNetworkRefs:
                               description: CustomNetworkRefs hold a list of custom
                                 providers to route traffic

--- a/config/crd/bases/rollouts.kruise.io_trafficroutings.yaml
+++ b/config/crd/bases/rollouts.kruise.io_trafficroutings.yaml
@@ -54,6 +54,11 @@ spec:
                     for supported service meshes to enable more fine-grained traffic
                     routing
                   properties:
+                    additionalParams:
+                      additionalProperties:
+                        type: string
+                      description: 'vaild keys:'
+                      type: object
                     customNetworkRefs:
                       description: CustomNetworkRefs hold a list of custom providers
                         to route traffic

--- a/lua_configuration/convert_test_case_to_lua_object.go
+++ b/lua_configuration/convert_test_case_to_lua_object.go
@@ -100,11 +100,14 @@ func objectToTable(path string) error {
 					Annotations: testCase.Original.GetAnnotations(),
 					Spec:        testCase.Original.Object["spec"],
 				},
-				Matches:       step.TrafficRoutingStrategy.Matches,
-				CanaryWeight:  *weight,
-				StableWeight:  100 - *weight,
-				CanaryService: canaryService,
-				StableService: stableService,
+				Matches:          step.TrafficRoutingStrategy.Matches,
+				CanaryWeight:     *weight,
+				StableWeight:     100 - *weight,
+				CanaryService:    canaryService,
+				StableService:    stableService,
+				StableRevision:   "podtemplatehash-v1",
+				CanaryRevision:   "podtemplatehash-v2",
+				RevisionLabelKey: "pod-template-hash",
 			}
 			uList[fmt.Sprintf("step_%d", i)] = data
 		}
@@ -128,11 +131,14 @@ func objectToTable(path string) error {
 				Annotations: testCase.Original.GetAnnotations(),
 				Spec:        testCase.Original.Object["spec"],
 			},
-			Matches:       matches,
-			CanaryWeight:  *weight,
-			StableWeight:  100 - *weight,
-			CanaryService: canaryService,
-			StableService: stableService,
+			Matches:          matches,
+			CanaryWeight:     *weight,
+			StableWeight:     100 - *weight,
+			CanaryService:    canaryService,
+			StableService:    stableService,
+			StableRevision:   "podtemplatehash-v1",
+			CanaryRevision:   "podtemplatehash-v2",
+			RevisionLabelKey: "pod-template-hash",
 		}
 		uList["steps_0"] = data
 	} else {

--- a/lua_configuration/networking.istio.io/DestinationRule/testdata/traffic_routing_with_a_match.yaml
+++ b/lua_configuration/networking.istio.io/DestinationRule/testdata/traffic_routing_with_a_match.yaml
@@ -16,6 +16,9 @@ trafficRouting:
       - apiVersion: networking.istio.io/v1beta1
         kind: DestinationRule
         name: ds-demo
+      additionalParams:
+        istio.destinationRule.stableSubsetName: "version-base"
+        istio.destinationRule.canarySubsetName: "canary"
 original:
   apiVersion: networking.istio.io/v1beta1
   kind: DestinationRule
@@ -27,9 +30,7 @@ original:
       loadBalancer:
         simple: ROUND_ROBIN
     subsets:
-      - labels:
-          version: base
-        name: version-base
+      - name: version-base
 expected:
   - apiVersion: networking.istio.io/v1beta1
     kind: DestinationRule
@@ -42,8 +43,8 @@ expected:
           simple: ROUND_ROBIN
       subsets:
         - labels:
-            version: base
+            pod-template-hash: "podtemplatehash-v1"
           name: version-base
         - labels:
-            istio.service.tag: gray
+            pod-template-hash: "podtemplatehash-v2"
           name: canary

--- a/lua_configuration/networking.istio.io/DestinationRule/trafficRouting.lua
+++ b/lua_configuration/networking.istio.io/DestinationRule/trafficRouting.lua
@@ -1,8 +1,51 @@
 local spec = obj.data.spec
+local podLabelKey = obj.revisionLabelKey
+
+if spec.subsets == nil then
+    spec.subsets = {}
+end
+
+-- selector lables might come from pod-template-hash and patchPodTemplateMetadata
+-- now we only support pod-template-hash
+local stableLabels = {}
+if obj.stableRevision ~= nil and obj.stableRevision ~= "" then
+    stableLabels[podLabelKey] = obj.stableRevision
+end
+local canaryLabels = {}
+if obj.canaryRevision ~= nil and obj.canaryRevision ~= "" then
+    canaryLabels[podLabelKey] = obj.canaryRevision
+end
+local StableNameAlreadyExist = false
+
+-- if stableName already exists, just appened the lables
+for _, subset in ipairs(spec.subsets) do
+    if subset.name == obj.stableName then
+        StableNameAlreadyExist = true
+        if next(stableLabels) ~= nil then
+            subset.labels = subset.labels or {}
+            for key, value in pairs(stableLabels) do
+                subset.labels[key] = value
+            end
+        end
+    end
+end
+-- if stableName doesn't exist, create it and its labels
+if not StableNameAlreadyExist then
+    local stable = {}
+    stable.name = obj.stableName
+    if next(stableLabels) ~= nil then
+        stable.labels = stableLabels
+    end
+    table.insert(spec.subsets, stable)
+end
+
+-- Aussue the canaryName never exist, create it and its labels
 local canary = {}
-canary.labels = {}
-canary.name = "canary"
-local podLabelKey = "istio.service.tag"
-canary.labels[podLabelKey] = "gray"
+canary.name = obj.canaryName
+if next(canaryLabels) ~= nil then
+    canary.labels = canaryLabels
+end
 table.insert(spec.subsets, canary)
+
+
 return obj.data

--- a/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_a_match.yaml
+++ b/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_a_match.yaml
@@ -19,6 +19,9 @@ trafficRouting:
       - apiVersion: networking.istio.io/v1alpha3
         kind: VirtualService
         name: vs-demo
+      additionalParams:
+        istio.destinationRule.stableSubsetName: "base"
+        istio.destinationRule.canarySubsetName: "canary"
 original:
   apiVersion: networking.istio.io/v1alpha3
   kind: VirtualService

--- a/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_matches.yaml
+++ b/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_matches.yaml
@@ -20,6 +20,9 @@ trafficRouting:
       - apiVersion: networking.istio.io/v1alpha3
         kind: VirtualService
         name: vs-demo
+      additionalParams:
+        istio.destinationRule.stableSubsetName: "base"
+        istio.destinationRule.canarySubsetName: "canary"
 original:
   apiVersion: networking.istio.io/v1alpha3
   kind: VirtualService

--- a/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_weight.yaml
+++ b/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_weight.yaml
@@ -12,6 +12,9 @@ trafficRouting:
       - apiVersion: networking.istio.io/v1alpha3
         kind: VirtualService
         name: vs-demo
+      additionalParams:
+        istio.destinationRule.stableSubsetName: "base"
+        istio.destinationRule.canarySubsetName: "canary"
 original:
   apiVersion: networking.istio.io/v1alpha3
   kind: VirtualService

--- a/lua_configuration/networking.istio.io/VirtualService/trafficRouting.lua
+++ b/lua_configuration/networking.istio.io/VirtualService/trafficRouting.lua
@@ -75,7 +75,7 @@ function GenerateRoutesWithMatches(spec, matches, stableService, canaryService)
         -- stableService == canaryService indicates DestinationRule exists and subset is set to be canary by default
         if stableService == canaryService then
             route.route[1].destination.host = stableService
-            route.route[1].destination.subset = "canary"
+            route.route[1].destination.subset = obj.canaryName
         else
             route.route[1].destination.host = canaryService
         end
@@ -99,7 +99,7 @@ function GenerateRoutes(spec, stableService, canaryService, stableWeight, canary
             canary = {
                 destination = {
                     host = stableService,
-                    subset = "canary",
+                    subset = obj.canaryName,
                 },
                 weight = canaryWeight,
             }

--- a/pkg/controller/rollout/rollout_canary.go
+++ b/pkg/controller/rollout/rollout_canary.go
@@ -250,14 +250,14 @@ func (m *canaryReleaseManager) doCanaryFinalising(c *RolloutContext) (bool, erro
 	if err != nil || !done {
 		return done, err
 	}
-	// 3. set workload.pause=false; set workload.partition=0
-	done, err = m.finalizingBatchRelease(c)
+	// 3. modify network api(ingress or gateway api) configuration, and route 100% traffic to stable pods.
+	done, err = m.trafficRoutingManager.FinalisingTrafficRouting(tr, false)
+	c.NewStatus.CanaryStatus.LastUpdateTime = tr.LastUpdateTime
 	if err != nil || !done {
 		return done, err
 	}
-	// 4. modify network api(ingress or gateway api) configuration, and route 100% traffic to stable pods.
-	done, err = m.trafficRoutingManager.FinalisingTrafficRouting(tr, false)
-	c.NewStatus.CanaryStatus.LastUpdateTime = tr.LastUpdateTime
+	// 4. set workload.pause=false; set workload.partition=0
+	done, err = m.finalizingBatchRelease(c)
 	if err != nil || !done {
 		return done, err
 	}

--- a/pkg/trafficrouting/manager.go
+++ b/pkg/trafficrouting/manager.go
@@ -278,14 +278,16 @@ func newNetworkProvider(c client.Client, con *TrafficRoutingContext, sService, c
 	trafficRouting := con.ObjectRef[0]
 	if trafficRouting.CustomNetworkRefs != nil {
 		return custom.NewCustomController(c, custom.Config{
-			Key:           con.Key,
-			RolloutNs:     con.Namespace,
-			CanaryService: cService,
-			StableService: sService,
-			TrafficConf:   trafficRouting.CustomNetworkRefs,
-			OwnerRef:      con.OwnerRef,
-			//only set for CustomController, never work for Ingress and Gateway
-			DisableGenerateCanaryService: con.DisableGenerateCanaryService,
+			Key:              con.Key,
+			RolloutNs:        con.Namespace,
+			CanaryService:    cService,
+			StableService:    sService,
+			TrafficConf:      trafficRouting.CustomNetworkRefs,
+			OwnerRef:         con.OwnerRef,
+			AdditionalParams: trafficRouting.AdditionalParams,
+			RevisionLabelKey: con.RevisionLabelKey,
+			StableRevision:   con.StableRevision,
+			CanaryRevision:   con.CanaryRevision,
 		})
 	}
 	if trafficRouting.Ingress != nil {

--- a/pkg/trafficrouting/network/customNetworkProvider/lua_configuration/networking.istio.io/DestinationRule/trafficRouting.lua
+++ b/pkg/trafficrouting/network/customNetworkProvider/lua_configuration/networking.istio.io/DestinationRule/trafficRouting.lua
@@ -1,8 +1,51 @@
 local spec = obj.data.spec
+local podLabelKey = obj.revisionLabelKey
+
+if spec.subsets == nil then
+    spec.subsets = {}
+end
+
+-- selector lables might come from pod-template-hash and patchPodTemplateMetadata
+-- now we only support pod-template-hash
+local stableLabels = {}
+if obj.stableRevision ~= nil and obj.stableRevision ~= "" then
+    stableLabels[podLabelKey] = obj.stableRevision
+end
+local canaryLabels = {}
+if obj.canaryRevision ~= nil and obj.canaryRevision ~= "" then
+    canaryLabels[podLabelKey] = obj.canaryRevision
+end
+local StableNameAlreadyExist = false
+
+-- if stableName already exists, just appened the lables
+for _, subset in ipairs(spec.subsets) do
+    if subset.name == obj.stableName then
+        StableNameAlreadyExist = true
+        if next(stableLabels) ~= nil then
+            subset.labels = subset.labels or {}
+            for key, value in pairs(stableLabels) do
+                subset.labels[key] = value
+            end
+        end
+    end
+end
+-- if stableName doesn't exist, create it and its labels
+if not StableNameAlreadyExist then
+    local stable = {}
+    stable.name = obj.stableName
+    if next(stableLabels) ~= nil then
+        stable.labels = stableLabels
+    end
+    table.insert(spec.subsets, stable)
+end
+
+-- Aussue the canaryName never exist, create it and its labels
 local canary = {}
-canary.labels = {}
-canary.name = "canary"
-local podLabelKey = "istio.service.tag"
-canary.labels[podLabelKey] = "gray"
+canary.name = obj.canaryName
+if next(canaryLabels) ~= nil then
+    canary.labels = canaryLabels
+end
 table.insert(spec.subsets, canary)
+
+
 return obj.data

--- a/pkg/trafficrouting/network/customNetworkProvider/lua_configuration/networking.istio.io/VirtualService/trafficRouting.lua
+++ b/pkg/trafficrouting/network/customNetworkProvider/lua_configuration/networking.istio.io/VirtualService/trafficRouting.lua
@@ -159,7 +159,7 @@ function GenerateMatchedRoutes(spec, matches, stableService, canaryService, stab
         -- if stableService == canaryService, then do e2e release
         if stableService == canaryService then
             route.route[1].destination.host = stableService
-            route.route[1].destination.subset = "canary"
+            route.route[1].destination.subset = obj.canaryName
         else
             route.route[1].destination.host = canaryService
         end
@@ -189,7 +189,7 @@ function GenerateRoutes(spec, stableService, canaryService, stableWeight, canary
             canary = {
                 destination = {
                     host = stableService,
-                    subset = "canary",
+                    subset = obj.canaryName,
                 },
                 weight = canaryWeight,
             }


### PR DESCRIPTION
... and add fields to allow user set canary/stable subset name

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
when work with Istio for trafficRouting, if spec.disableGenerateCanaryService is set true and Istio DestinationRule is provided, Rollout won't create canary service but create a canary subset. The stable subset(if not provided in  DestinationRule, stable subset will be create also) and canary subset are distinct with label selectors, which are respectively pod-template-hash of v1 and v2. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Special notes for reviews
