### PR TITLE
add 2 fields to status to support showing result of kubectl get

### DIFF
--- a/api/v1beta1/rollout_types.go
+++ b/api/v1beta1/rollout_types.go
@@ -308,6 +308,10 @@ type RolloutStatus struct {
 	Phase RolloutPhase `json:"phase,omitempty"`
 	// Message provides details on why the rollout is in its current phase
 	Message string `json:"message,omitempty"`
+	// These two values will be synchronized with the same fileds in CanaryStatus or BlueGreeenStatus
+	// mainly used to provide info for kubectl get command
+	CurrentStepIndex int32           `json:"currentStepIndex"`
+	CurrentStepState CanaryStepState `json:"currentStepState"`
 }
 
 // RolloutCondition describes the state of a rollout at a certain point.
@@ -430,6 +434,9 @@ type BlueGreenStatus struct {
 
 // GetSubStatus returns the ethier canary or bluegreen status
 func (r *RolloutStatus) GetSubStatus() *CommonStatus {
+	if r.CanaryStatus == nil && r.BlueGreenStatus == nil {
+		return nil
+	}
 	if r.CanaryStatus != nil {
 		return &(r.CanaryStatus.CommonStatus)
 	}
@@ -559,8 +566,8 @@ const (
 //+kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.phase",description="The rollout status phase"
-// +kubebuilder:printcolumn:name="CANARY_STEP",type="integer",JSONPath=".status.canaryStatus.currentStepIndex",description="The rollout canary status step"
-// +kubebuilder:printcolumn:name="CANARY_STATE",type="string",JSONPath=".status.canaryStatus.currentStepState",description="The rollout canary status step state"
+// +kubebuilder:printcolumn:name="CANARY_STEP",type="integer",JSONPath=".status.currentStepIndex",description="The rollout canary status step"
+// +kubebuilder:printcolumn:name="CANARY_STATE",type="string",JSONPath=".status.currentStepState",description="The rollout canary status step state"
 // +kubebuilder:printcolumn:name="MESSAGE",type="string",JSONPath=".status.message",description="The rollout canary status message"
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 

--- a/config/crd/bases/rollouts.kruise.io_rollouts.yaml
+++ b/config/crd/bases/rollouts.kruise.io_rollouts.yaml
@@ -548,11 +548,11 @@ spec:
       name: STATUS
       type: string
     - description: The rollout canary status step
-      jsonPath: .status.canaryStatus.currentStepIndex
+      jsonPath: .status.currentStepIndex
       name: CANARY_STEP
       type: integer
     - description: The rollout canary status step state
-      jsonPath: .status.canaryStatus.currentStepState
+      jsonPath: .status.currentStepState
       name: CANARY_STATE
       type: string
     - description: The rollout canary status message
@@ -1594,6 +1594,14 @@ spec:
                   - type
                   type: object
                 type: array
+              currentStepIndex:
+                description: These two values will be synchronized with the same fileds
+                  in CanaryStatus or BlueGreeenStatus mainly used to provide info
+                  for kubectl get command
+                format: int32
+                type: integer
+              currentStepState:
+                type: string
               message:
                 description: Message provides details on why the rollout is in its
                   current phase
@@ -1607,6 +1615,9 @@ spec:
                 description: BlueGreenStatus *BlueGreenStatus `json:"blueGreenStatus,omitempty"`
                   Phase is the rollout phase.
                 type: string
+            required:
+            - currentStepIndex
+            - currentStepState
             type: object
         type: object
     served: true

--- a/pkg/controller/rollout/rollout_progressing.go
+++ b/pkg/controller/rollout/rollout_progressing.go
@@ -78,6 +78,8 @@ func (r *RolloutReconciler) reconcileRolloutProgressing(rollout *v1beta1.Rollout
 			CurrentStepState:           v1beta1.CanaryStepStateInit,
 			LastUpdateTime:             &metav1.Time{Time: time.Now()},
 		}
+		newStatus.CurrentStepIndex = commonStatus.CurrentStepIndex
+		newStatus.CurrentStepState = commonStatus.CurrentStepState
 		if rollout.Spec.Strategy.IsBlueGreenRelease() {
 			newStatus.BlueGreenStatus = &v1beta1.BlueGreenStatus{
 				CommonStatus:    commonStatus,

--- a/pkg/controller/rollout/rollout_progressing_test.go
+++ b/pkg/controller/rollout/rollout_progressing_test.go
@@ -72,6 +72,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				s.CanaryStatus.NextStepIndex = 2
 				// now the first step is no longer StepStateUpgrade, it is StepStateInit now
 				s.CanaryStatus.CurrentStepState = v1beta1.CanaryStepStateInit
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 			expectTr: func() *v1alpha1.TrafficRouting {
@@ -108,6 +110,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
 				util.SetRolloutCondition(s, *cond)
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 		},
@@ -165,6 +169,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
 				util.SetRolloutCondition(s, *cond)
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 		},
@@ -223,6 +229,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				cond.Reason = v1alpha1.ProgressingReasonFinalising
 				cond.Status = corev1.ConditionTrue
 				util.SetRolloutCondition(s, *cond)
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 		},
@@ -282,6 +290,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				cond.Reason = v1alpha1.ProgressingReasonFinalising
 				cond.Status = corev1.ConditionTrue
 				util.SetRolloutCondition(s, *cond)
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 			expectTr: func() *v1alpha1.TrafficRouting {
@@ -343,6 +353,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				cond2.Reason = v1alpha1.ProgressingReasonFinalising
 				cond2.Status = corev1.ConditionTrue
 				util.SetRolloutCondition(s, *cond2)
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 		},
@@ -397,6 +409,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				cond1.LastUpdateTime = metav1.Time{}
 				cond1.LastTransitionTime = metav1.Time{}
 				util.SetRolloutCondition(s, *cond1)
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 		},
@@ -454,6 +468,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonCancelling
 				util.SetRolloutCondition(s, *cond)
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 		},
@@ -511,6 +527,8 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonCancelling
 				util.SetRolloutCondition(s, *cond)
+				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
+				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				return s
 			},
 		},

--- a/pkg/controller/rollout/rollout_status.go
+++ b/pkg/controller/rollout/rollout_status.go
@@ -204,6 +204,10 @@ func (r *RolloutReconciler) calculateRolloutHash(rollout *v1beta1.Rollout) error
 }
 
 func (r *RolloutReconciler) updateRolloutStatusInternal(rollout *v1beta1.Rollout, newStatus v1beta1.RolloutStatus) error {
+	if newStatus.GetSubStatus() != nil {
+		newStatus.CurrentStepIndex = newStatus.GetSubStatus().CurrentStepIndex
+		newStatus.CurrentStepState = newStatus.GetSubStatus().CurrentStepState
+	}
 	if reflect.DeepEqual(rollout.Status, newStatus) {
 		return nil
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
if we run `kubectl get rollout rollouts-demo`, we get result like this:
<img width="772" alt="image" src="https://github.com/openkruise/rollouts/assets/57184070/38adfca2-acb9-4198-8c2f-9994b50c5274">

the CANARY_STEP and CANARY_STATE are read from `rollout.status.CanaryStatus`, however, if we support blue-green, we cannot read the values from this path anymore, because the CanaryStatus will be nil. Therefore, i add copies of these two fields to `rollout.status`. They are only used to showing the brief result returned from kubectl get command.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
no
### Ⅲ. Special notes for reviews
