### PR TITLE
Inject requestHeaderModifier to LuaData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ test/e2e/generated/bindata.go
 .vscode
 
 .DS_Store
+
+lua_configuration/networking.istio.io/**/testdata/*.lua

--- a/lua_configuration/convert_test_case_to_lua_object.go
+++ b/lua_configuration/convert_test_case_to_lua_object.go
@@ -100,11 +100,12 @@ func objectToTable(path string) error {
 					Annotations: testCase.Original.GetAnnotations(),
 					Spec:        testCase.Original.Object["spec"],
 				},
-				Matches:       step.TrafficRoutingStrategy.Matches,
-				CanaryWeight:  *weight,
-				StableWeight:  100 - *weight,
-				CanaryService: canaryService,
-				StableService: stableService,
+				Matches:               step.TrafficRoutingStrategy.Matches,
+				CanaryWeight:          *weight,
+				StableWeight:          100 - *weight,
+				CanaryService:         canaryService,
+				StableService:         stableService,
+				RequestHeaderModifier: step.TrafficRoutingStrategy.RequestHeaderModifier,
 			}
 			uList[fmt.Sprintf("step_%d", i)] = data
 		}
@@ -128,11 +129,12 @@ func objectToTable(path string) error {
 				Annotations: testCase.Original.GetAnnotations(),
 				Spec:        testCase.Original.Object["spec"],
 			},
-			Matches:       matches,
-			CanaryWeight:  *weight,
-			StableWeight:  100 - *weight,
-			CanaryService: canaryService,
-			StableService: stableService,
+			Matches:               matches,
+			CanaryWeight:          *weight,
+			StableWeight:          100 - *weight,
+			CanaryService:         canaryService,
+			StableService:         stableService,
+			RequestHeaderModifier: trafficRouting.Spec.Strategy.RequestHeaderModifier,
 		}
 		uList["steps_0"] = data
 	} else {

--- a/lua_configuration/networking.istio.io/VirtualService/testdata/rollout_with_three_steps.yaml
+++ b/lua_configuration/networking.istio.io/VirtualService/testdata/rollout_with_three_steps.yaml
@@ -19,6 +19,10 @@ rollout:
             - type: RegularExpression
               name: name
               value: ".*demo"
+          requestHeaderModifier:
+            set:
+            - name: "header-foo"
+              value: "bar"
         - matches:
           - headers:
             - type: Exact
@@ -66,6 +70,10 @@ expected:
               exact: pc
             name:
               regex: .*demo
+        headers:
+          request:
+            set:
+              header-foo: bar
         route:
         - destination:
             host: svc-demo-canary

--- a/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_a_match.yaml
+++ b/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_a_match.yaml
@@ -13,6 +13,10 @@ trafficRouting:
         - type: RegularExpression
           name: name
           value: ".*demo"
+      requestHeaderModifier:
+        set:
+        - name: "header-foo"
+          value: "bar"
     objectRef:
     - service: svc-demo
       customNetworkRefs:
@@ -51,6 +55,10 @@ expected:
               exact: pc
             name:
               regex: .*demo
+        headers:
+          request:
+            set:
+              header-foo: bar
         route:
         - destination:
             host: svc-demo

--- a/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_matches.yaml
+++ b/lua_configuration/networking.istio.io/VirtualService/testdata/traffic_routing_with_matches.yaml
@@ -14,6 +14,10 @@ trafficRouting:
         - type: RegularExpression
           name: name
           value: ".*demo"
+      requestHeaderModifier:
+        set:
+        - name: "header-foo"
+          value: "bar"
     objectRef:
     - service: svc-demo
       customNetworkRefs:
@@ -50,6 +54,10 @@ expected:
         - headers:
             name:
               regex: .*demo
+        headers:
+          request:
+            set:
+              header-foo: bar
         route:
         - destination:
             host: svc-demo
@@ -58,6 +66,10 @@ expected:
         - headers:
             user-agent:
               exact: pc
+        headers:
+          request:
+            set:
+              header-foo: bar
         route:
         - destination:
             host: svc-demo


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

In `TrafficRoutingStrategy` struct, `RequestHeaderModifier` is allowed to be used for request header modification.
But this field was not actually injected to the LuaData. Thus it cannot be used in the script.

Istio also supports HeaderOperations,

https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers-HeaderOperations

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Special notes for reviews
