### PR TITLE
improve finalising logic for canary release

### DIFF
--- a/api/v1alpha1/rollout_types.go
+++ b/api/v1alpha1/rollout_types.go
@@ -171,8 +171,6 @@ type RolloutStatus struct {
 	// Conditions a list of conditions a rollout can have.
 	// +optional
 	Conditions []RolloutCondition `json:"conditions,omitempty"`
-	// +optional
-	//BlueGreenStatus *BlueGreenStatus `json:"blueGreenStatus,omitempty"`
 	// Phase is the rollout phase.
 	Phase RolloutPhase `json:"phase,omitempty"`
 	// Message provides details on why the rollout is in its current phase

--- a/api/v1beta1/rollout_types.go
+++ b/api/v1beta1/rollout_types.go
@@ -445,7 +445,7 @@ type CanaryStatus struct {
 // BlueGreenStatus status fields that only pertain to the blueGreen rollout
 type BlueGreenStatus struct {
 	CommonStatus `json:",inline"`
-	// CanaryRevision is calculated by rollout based on podTemplateHash, and the internal logic flow uses
+	// UpdatedRevision is calculated by rollout based on podTemplateHash, and the internal logic flow uses
 	// It may be different from rs podTemplateHash in different k8s versions, so it cannot be used as service selector label
 	UpdatedRevision string `json:"updatedRevision"`
 	// UpdatedReplicas the numbers of updated pods
@@ -558,29 +558,29 @@ const (
 type FinalisingStepType string
 
 const (
-	// some work that should be done before pod scaling down.
-	// For BlueGreenStrategy:
-	// we rout all traffic to stable or new version based on FinaliseReason
-	// For CanaryStrategy:
-	// we remove the selector of stable service
-	FinalisingStepTypePreparing FinalisingStepType = "Preparing"
+	// Route all traffic to stable or new version based on FinaliseReason (for bluegreen)
+	FinalisingStepTypeRouteAllTraffic FinalisingStepType = "RouteAllTraffic"
+	// Restore the stable Service, i.e. remove corresponding selector
+	FinalisingStepTypeStableService FinalisingStepType = "RestoreStableService"
+	// Remove the canary Service
+	FinalisingStepTypeRemoveCanaryService FinalisingStepType = "RemoveCanaryService"
+
 	// Patch Batch Release to scale down (exception: the canary Deployment will be
 	// scaled down in FinalisingStepTypeDeleteBR step)
 	// For Both BlueGreenStrategy and CanaryStrategy:
 	// set workload.pause=false, set workload.partition=0
 	FinalisingStepTypeBatchRelease FinalisingStepType = "PatchBatchRelease"
-	//TODO - Currently, the next three steps are in the same function, FinalisingTrafficRouting
-	// we should try to separate the FinalisingStepTypeGateway and FinalisingStepTypeCanaryService
-	// with graceful time to prevent some potential issues
 
-	// Restore the stable Service (i.e. remove corresponding selector)
-	FinalisingStepTypeStableService FinalisingStepType = "RestoreStableService"
+	// Execute the FinalisingTrafficRouting function
+	FinalisingStepTypeTrafficRouting FinalisingStepType = "FinalisingTrafficRouting"
 	// Restore the GatewayAPI/Ingress/Istio
 	FinalisingStepTypeGateway FinalisingStepType = "RestoreGateway"
 	// Delete Canary Service
 	FinalisingStepTypeDeleteCanaryService FinalisingStepType = "DeleteCanaryService"
 	// Delete Batch Release
 	FinalisingStepTypeDeleteBR FinalisingStepType = "DeleteBatchRelease"
+	// All needed work done
+	FinalisingStepTypeEnd FinalisingStepType = "END"
 )
 
 // +genclient

--- a/config/crd/bases/rollouts.kruise.io_rollouts.yaml
+++ b/config/crd/bases/rollouts.kruise.io_rollouts.yaml
@@ -534,8 +534,7 @@ spec:
                 format: int64
                 type: integer
               phase:
-                description: BlueGreenStatus *BlueGreenStatus `json:"blueGreenStatus,omitempty"`
-                  Phase is the rollout phase.
+                description: Phase is the rollout phase.
                 type: string
             type: object
         type: object
@@ -1475,7 +1474,7 @@ spec:
                     format: int32
                     type: integer
                   updatedRevision:
-                    description: CanaryRevision is calculated by rollout based on
+                    description: UpdatedRevision is calculated by rollout based on
                       podTemplateHash, and the internal logic flow uses It may be
                       different from rs podTemplateHash in different k8s versions,
                       so it cannot be used as service selector label

--- a/pkg/controller/rollout/rollout_status.go
+++ b/pkg/controller/rollout/rollout_status.go
@@ -238,7 +238,7 @@ func (r *RolloutReconciler) reconcileRolloutTerminating(rollout *v1beta1.Rollout
 		klog.Errorf("rollout(%s/%s) get workload failed: %s", rollout.Namespace, rollout.Name, err.Error())
 		return nil, err
 	}
-	c := &RolloutContext{Rollout: rollout, NewStatus: newStatus, Workload: workload}
+	c := &RolloutContext{Rollout: rollout, NewStatus: newStatus, Workload: workload, FinalizeReason: v1beta1.FinaliseReasonDelete}
 	done, err := r.doFinalising(c)
 	if err != nil {
 		return nil, err
@@ -262,7 +262,7 @@ func (r *RolloutReconciler) reconcileRolloutDisabling(rollout *v1beta1.Rollout, 
 		klog.Errorf("rollout(%s/%s) get workload failed: %s", rollout.Namespace, rollout.Name, err.Error())
 		return nil, err
 	}
-	c := &RolloutContext{Rollout: rollout, NewStatus: newStatus, Workload: workload}
+	c := &RolloutContext{Rollout: rollout, NewStatus: newStatus, Workload: workload, FinalizeReason: v1beta1.FinaliseReasonDisalbed}
 	done, err := r.doFinalising(c)
 	if err != nil {
 		return nil, err

--- a/pkg/trafficrouting/manager.go
+++ b/pkg/trafficrouting/manager.go
@@ -204,26 +204,25 @@ func (m *Manager) FinalisingTrafficRouting(c *TrafficRoutingContext) (bool, erro
 	if len(c.ObjectRef) == 0 {
 		return true, nil
 	}
-	klog.Infof("%s start finalising traffic routing", c.Key)
-	// remove stable service the pod revision selector, so stable service will be selector all version pods.
+	klog.InfoS("start finalising traffic routing", "rollout", c.Key)
+	// remove stable service the pod revision selector, so stable service will select pods of all versions.
 	if retry, err := m.RestoreStableService(c); err != nil || retry {
 		return false, err
 	}
-	klog.Infof("%s restore stable service success", c.Key)
+	klog.InfoS("restore stable service success", "rollout", c.Key)
 	// modify network(ingress & gateway api) configuration, route all traffic to stable service
 	if retry, err := m.RestoreGateway(c); err != nil || retry {
 		return false, err
 	}
-	klog.Infof("%s restore gateway success", c.Key)
+	klog.InfoS("restore gateway success", "rollout", c.Key)
 	// remove canary service
 	if retry, err := m.RemoveCanaryService(c); err != nil || retry {
 		return false, err
 	}
-	klog.Infof("%s remove canary service success, finalising traffic routing is done", c.Key)
+	klog.InfoS("remove canary service success, finalising traffic routing is done", "rollout", c.Key)
 	return true, nil
 }
 
-// RestoreGateway restore gateway resources without graceful time
 // returns:
 //   - if error is not nil, usually we need to retry later. Only if error is nil, we consider the bool.
 //   - The bool value indicates whether retry is needed. If true, it usually means

--- a/test/e2e/rollout_v1beta1_test.go
+++ b/test/e2e/rollout_v1beta1_test.go
@@ -213,7 +213,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			body := fmt.Sprintf(`{"status":{"canaryStatus":{"currentStepState":"%s"}}}`, v1beta1.CanaryStepStateReady)
 			Expect(k8sClient.Status().Patch(context.TODO(), clone, client.RawPatch(types.MergePatchType, []byte(body)))).NotTo(HaveOccurred())
 			return false
-		}, 10*time.Second, time.Second).Should(BeTrue())
+		}, 10*time.Second, time.Millisecond*500).Should(BeTrue())
 	}
 
 	RolloutJumpCanaryStep := func(name string, target int) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->
### Ⅰ. Describe what this PR does
rewrite the doCanaryFinalising function, mainly to modify the logic of rollback
before, this function executes the same steps for rollback and other scenarios (including success, pause, disabling):
1. restore the stable service (remove selector)
2. finalizingBatchRelease
3. modify network configuration (ingress/istio/gateway api configuration), and route 100% traffic to stable pods
4. delete BatchRelease

however, in rollback scenario, running the first step (remove selector) will route some traffic unexpectedly to new version if user does A/B testing. Therefore, in rollback scenario, we instead route all traffic to stable service firstly, like:

1. route all traffic to stable service (by restoring ingress/istio/gateway api directly)
2. finalizingBatchRelease
3. delete BatchRelease
4. restore stable service, remove canary service

note: i am not intended to modify the behaviours other than rollback (ie. success, pause, disabling), however, i find it is possible to simplify it, by combing the first step and the third step:
1. call traffic finalising function to (restore stable service-> restore  ingress/istio/gateway api -> remove canary service) in one go
2. finalizingBatchRelease
3. delete BatchRelease

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
no
### Ⅲ. Special notes for reviews
