### PR TITLE
Patch canary service selector from PodTemplateMetadata

### DIFF
--- a/pkg/controller/rollout/rollout_progressing.go
+++ b/pkg/controller/rollout/rollout_progressing.go
@@ -600,11 +600,16 @@ func newTrafficRoutingContext(c *RolloutContext) *trafficrouting.TrafficRoutingC
 	if c.Workload != nil {
 		revisionLabelKey = c.Workload.RevisionLabelKey
 	}
+	var selectorPatch map[string]string
+	if c.Rollout.Spec.Strategy.GetRollingStyle() == v1beta1.CanaryRollingStyle {
+		selectorPatch = c.Rollout.Spec.Strategy.Canary.PatchPodTemplateMetadata.Labels
+	}
 	return &trafficrouting.TrafficRoutingContext{
 		Key:                          fmt.Sprintf("Rollout(%s/%s)", c.Rollout.Namespace, c.Rollout.Name),
 		Namespace:                    c.Rollout.Namespace,
 		ObjectRef:                    c.Rollout.Spec.Strategy.GetTrafficRouting(),
 		Strategy:                     currentStep.TrafficRoutingStrategy,
+		CanaryServiceSelectorPatch:   selectorPatch,
 		OwnerRef:                     *metav1.NewControllerRef(c.Rollout, rolloutControllerKind),
 		RevisionLabelKey:             revisionLabelKey,
 		StableRevision:               c.NewStatus.GetSubStatus().StableRevision,

--- a/pkg/controller/rollout/rollout_progressing.go
+++ b/pkg/controller/rollout/rollout_progressing.go
@@ -601,7 +601,7 @@ func newTrafficRoutingContext(c *RolloutContext) *trafficrouting.TrafficRoutingC
 		revisionLabelKey = c.Workload.RevisionLabelKey
 	}
 	var selectorPatch map[string]string
-	if c.Rollout.Spec.Strategy.GetRollingStyle() == v1beta1.CanaryRollingStyle {
+	if !c.Rollout.Spec.Strategy.DisableGenerateCanaryService() && c.Rollout.Spec.Strategy.Canary.PatchPodTemplateMetadata != nil {
 		selectorPatch = c.Rollout.Spec.Strategy.Canary.PatchPodTemplateMetadata.Labels
 	}
 	return &trafficrouting.TrafficRoutingContext{

--- a/pkg/feature/rollout_features.go
+++ b/pkg/feature/rollout_features.go
@@ -28,11 +28,14 @@ const (
 	RolloutHistoryGate featuregate.Feature = "RolloutHistory"
 	// AdvancedDeploymentGate enable advanced deployment controller.
 	AdvancedDeploymentGate featuregate.Feature = "AdvancedDeployment"
+	// AppendServiceSelectorGate enable appending pod labels from PodTemplateMetadata to the canary service selector.
+	AppendServiceSelectorGate featuregate.Feature = "AppendPodSelector"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	RolloutHistoryGate:     {Default: false, PreRelease: featuregate.Alpha},
-	AdvancedDeploymentGate: {Default: false, PreRelease: featuregate.Alpha},
+	RolloutHistoryGate:        {Default: false, PreRelease: featuregate.Alpha},
+	AdvancedDeploymentGate:    {Default: false, PreRelease: featuregate.Alpha},
+	AppendServiceSelectorGate: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/trafficrouting/manager.go
+++ b/pkg/trafficrouting/manager.go
@@ -44,10 +44,11 @@ var (
 
 type TrafficRoutingContext struct {
 	// only for log info
-	Key       string
-	Namespace string
-	ObjectRef []v1beta1.TrafficRoutingRef
-	Strategy  v1beta1.TrafficRoutingStrategy
+	Key                        string
+	Namespace                  string
+	ObjectRef                  []v1beta1.TrafficRoutingRef
+	Strategy                   v1beta1.TrafficRoutingStrategy
+	CanaryServiceSelectorPatch map[string]string
 	// OnlyTrafficRouting
 	OnlyTrafficRouting bool
 	OwnerRef           metav1.OwnerReference
@@ -446,6 +447,12 @@ func (m *Manager) createCanaryService(c *TrafficRoutingContext, cService string,
 	// avoid port conflicts for NodePort-type service
 	for i := range canaryService.Spec.Ports {
 		canaryService.Spec.Ports[i].NodePort = 0
+	}
+	for key, val := range c.CanaryServiceSelectorPatch {
+		// TODO: add feature gate to support add more selector
+		if _, ok := canaryService.Spec.Selector[key]; ok {
+			canaryService.Spec.Selector[key] = val
+		}
 	}
 	err := m.Create(context.TODO(), canaryService)
 	if err != nil && !errors.IsAlreadyExists(err) {

--- a/pkg/trafficrouting/manager.go
+++ b/pkg/trafficrouting/manager.go
@@ -451,13 +451,11 @@ func (m *Manager) createCanaryService(c *TrafficRoutingContext, cService string,
 	for i := range canaryService.Spec.Ports {
 		canaryService.Spec.Ports[i].NodePort = 0
 	}
-	if len(c.CanaryServiceSelectorPatch) > 0 {
-		for key, val := range c.CanaryServiceSelectorPatch {
-			if _, ok := canaryService.Spec.Selector[key]; ok {
-				canaryService.Spec.Selector[key] = val
-			} else if utilfeature.DefaultFeatureGate.Enabled(feature.AppendServiceSelectorGate) {
-				canaryService.Spec.Selector[key] = val
-			}
+	for key, val := range c.CanaryServiceSelectorPatch {
+		if _, ok := canaryService.Spec.Selector[key]; ok {
+			canaryService.Spec.Selector[key] = val
+		} else if utilfeature.DefaultFeatureGate.Enabled(feature.AppendServiceSelectorGate) {
+			canaryService.Spec.Selector[key] = val
 		}
 	}
 	err := m.Create(context.TODO(), canaryService)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

 - [x] Allow to overwrite existing service selector if PodTemplateMetadataPatch exists for Canary style
 - [x] Add a feature gate to allow appending pod labels to the service selector even if the labels does not exist in the stable service

### Ⅱ. Does this pull request fix one issue?

Fix #241 

### Ⅲ. Special notes for reviews
