### PR TITLE
Patch rollout-batch-id even without rollout-id in workload

### DIFF
--- a/pkg/controller/rollout/rollout_bluegreen_test.go
+++ b/pkg/controller/rollout/rollout_bluegreen_test.go
@@ -64,6 +64,7 @@ func TestBlueGreenRunCanary(t *testing.T) {
 				obj.Status.BlueGreenStatus.UpdatedRevision = "6f8cc56547"
 				obj.Status.BlueGreenStatus.CurrentStepIndex = 1
 				obj.Status.BlueGreenStatus.NextStepIndex = 2
+				obj.Status.BlueGreenStatus.ObservedRolloutID = "88bd5dbfd"
 				obj.Status.BlueGreenStatus.CurrentStepState = v1beta1.CanaryStepStateUpgrade
 				cond := util.GetRolloutCondition(obj.Status, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
@@ -79,6 +80,7 @@ func TestBlueGreenRunCanary(t *testing.T) {
 				s.BlueGreenStatus.CurrentStepIndex = 1
 				s.BlueGreenStatus.NextStepIndex = 2
 				s.BlueGreenStatus.CurrentStepState = v1beta1.CanaryStepStateUpgrade
+				s.BlueGreenStatus.ObservedRolloutID = "88bd5dbfd"
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
 				util.SetRolloutCondition(s, *cond)
@@ -102,6 +104,7 @@ func TestBlueGreenRunCanary(t *testing.T) {
 				}
 				br.Spec.ReleasePlan.BatchPartition = utilpointer.Int32(0)
 				br.Spec.ReleasePlan.RollingStyle = v1beta1.BlueGreenRollingStyle
+				br.Spec.ReleasePlan.RolloutID = "88bd5dbfd"
 				return br
 			},
 		},
@@ -128,6 +131,7 @@ func TestBlueGreenRunCanary(t *testing.T) {
 				obj.Status.BlueGreenStatus.CurrentStepIndex = 1
 				obj.Status.BlueGreenStatus.NextStepIndex = 2
 				obj.Status.BlueGreenStatus.CurrentStepState = v1beta1.CanaryStepStateUpgrade
+				obj.Status.BlueGreenStatus.ObservedRolloutID = "88bd5dbfd"
 				cond := util.GetRolloutCondition(obj.Status, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
 				util.SetRolloutCondition(&obj.Status, *cond)
@@ -148,6 +152,7 @@ func TestBlueGreenRunCanary(t *testing.T) {
 				}
 				br.Spec.ReleasePlan.BatchPartition = utilpointer.Int32(0)
 				br.Spec.ReleasePlan.RollingStyle = v1beta1.BlueGreenRollingStyle
+				br.Spec.ReleasePlan.RolloutID = "88bd5dbfd"
 				br.Status = v1beta1.BatchReleaseStatus{
 					ObservedGeneration:      1,
 					ObservedReleasePlanHash: util.HashReleasePlanBatches(&br.Spec.ReleasePlan),
@@ -171,6 +176,7 @@ func TestBlueGreenRunCanary(t *testing.T) {
 				s.BlueGreenStatus.UpdatedReadyReplicas = 1
 				s.BlueGreenStatus.CurrentStepIndex = 1
 				s.BlueGreenStatus.NextStepIndex = 2
+				s.BlueGreenStatus.ObservedRolloutID = "88bd5dbfd"
 				s.BlueGreenStatus.CurrentStepState = v1beta1.CanaryStepStateTrafficRouting
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
@@ -195,6 +201,7 @@ func TestBlueGreenRunCanary(t *testing.T) {
 				}
 				br.Spec.ReleasePlan.BatchPartition = utilpointer.Int32(0)
 				br.Spec.ReleasePlan.RollingStyle = v1beta1.BlueGreenRollingStyle
+				br.Spec.ReleasePlan.RolloutID = "88bd5dbfd"
 				return br
 			},
 		},

--- a/pkg/controller/rollout/rollout_canary_test.go
+++ b/pkg/controller/rollout/rollout_canary_test.go
@@ -103,6 +103,7 @@ func TestRunCanary(t *testing.T) {
 				br.Spec.ReleasePlan.BatchPartition = utilpointer.Int32(0)
 				br.Spec.ReleasePlan.EnableExtraWorkloadForCanary = true
 				br.Spec.ReleasePlan.RollingStyle = v1beta1.CanaryRollingStyle
+				br.Spec.ReleasePlan.RolloutID = "88bd5dbfd"
 				return br
 			},
 		},
@@ -143,6 +144,7 @@ func TestRunCanary(t *testing.T) {
 				obj.Status.CanaryStatus.CurrentStepIndex = 1
 				obj.Status.CanaryStatus.NextStepIndex = 2
 				obj.Status.CanaryStatus.CurrentStepState = v1beta1.CanaryStepStateUpgrade
+				obj.Status.CanaryStatus.ObservedRolloutID = "88bd5dbfd"
 				cond := util.GetRolloutCondition(obj.Status, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
 				util.SetRolloutCondition(&obj.Status, *cond)
@@ -164,6 +166,7 @@ func TestRunCanary(t *testing.T) {
 				br.Spec.ReleasePlan.BatchPartition = utilpointer.Int32(0)
 				br.Spec.ReleasePlan.EnableExtraWorkloadForCanary = true
 				br.Spec.ReleasePlan.RollingStyle = v1beta1.CanaryRollingStyle
+				br.Spec.ReleasePlan.RolloutID = "88bd5dbfd"
 				br.Status = v1beta1.BatchReleaseStatus{
 					ObservedGeneration: 1,
 					// since we use RollingStyle over EnableExtraWorkloadForCanary now, former hardcoded hash
@@ -190,6 +193,7 @@ func TestRunCanary(t *testing.T) {
 				s.CanaryStatus.CurrentStepIndex = 1
 				s.CanaryStatus.NextStepIndex = 2
 				s.CanaryStatus.CurrentStepState = v1beta1.CanaryStepStateTrafficRouting
+				s.CanaryStatus.ObservedRolloutID = "88bd5dbfd"
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
 				util.SetRolloutCondition(s, *cond)
@@ -214,6 +218,7 @@ func TestRunCanary(t *testing.T) {
 				br.Spec.ReleasePlan.BatchPartition = utilpointer.Int32(0)
 				br.Spec.ReleasePlan.EnableExtraWorkloadForCanary = true
 				br.Spec.ReleasePlan.RollingStyle = v1beta1.CanaryRollingStyle
+				br.Spec.ReleasePlan.RolloutID = "88bd5dbfd"
 				return br
 			},
 		},

--- a/pkg/controller/rollout/rollout_progressing_test.go
+++ b/pkg/controller/rollout/rollout_progressing_test.go
@@ -74,6 +74,7 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				s.CanaryStatus.CurrentStepState = v1beta1.CanaryStepStateInit
 				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
 				s.CurrentStepState = s.CanaryStatus.CurrentStepState
+				s.CanaryStatus.ObservedRolloutID = "88bd5dbfd"
 				return s
 			},
 			expectTr: func() *v1alpha1.TrafficRouting {
@@ -107,6 +108,7 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				s.CanaryStatus.CurrentStepIndex = 1
 				s.CanaryStatus.NextStepIndex = 2
 				s.CanaryStatus.CurrentStepState = v1beta1.CanaryStepStateInit
+				s.CanaryStatus.ObservedRolloutID = "88bd5dbfd"
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling
 				util.SetRolloutCondition(s, *cond)

--- a/pkg/controller/rollout/rollout_status.go
+++ b/pkg/controller/rollout/rollout_status.go
@@ -119,7 +119,7 @@ func (r *RolloutReconciler) calculateRolloutStatus(rollout *v1beta1.Rollout) (re
 			//	   newStatus.CanaryStatus.CurrentStepState == "Completed" {
 			//	   // do something after rollout
 			//   }
-			//```
+			// ```
 			// But at the first deployment of Rollout/Workload, CanaryStatus isn't set due to no rollout progression,
 			// and PaaS platform cannot judge whether the deployment is completed base on the code above. So we have
 			// to update the status just like the rollout was completed.
@@ -349,7 +349,14 @@ func (r *RolloutReconciler) handleFinalizer(rollout *v1beta1.Rollout) error {
 
 func getRolloutID(workload *util.Workload) string {
 	if workload != nil {
-		return workload.Labels[v1beta1.RolloutIDLabel]
+		rolloutID := workload.Labels[v1beta1.RolloutIDLabel]
+		if rolloutID == "" {
+			rolloutID = workload.CanaryRevision
+			if workload.IsInRollback {
+				rolloutID = fmt.Sprintf("rollback-%s", rolloutID)
+			}
+		}
+		return rolloutID
 	}
 	return ""
 }


### PR DESCRIPTION
**Ⅰ. Describe what this PR does**
1. patch rollout-batch-id even without rollout-id in workload

**Ⅱ. Does this pull request fix one issue?**
https://github.com/openkruise/rollouts/issues/244

Ⅲ. Special notes for reviews