### PR TITLE
Fix: blue-green batch-id e2e fails sometime

### DIFF
--- a/.github/workflows/e2e-v1beta1-bluegreen-1.19.yaml
+++ b/.github/workflows/e2e-v1beta1-bluegreen-1.19.yaml
@@ -97,7 +97,7 @@ jobs:
           set +e
           ./bin/ginkgo -timeout 60m -v --focus='bluegreen disable hpa test case - autoscaling/v1 for v1.19' test/e2e
           retVal=$?
-          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
           restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
           if [ "${restartCount}" -eq "0" ];then
               echo "Kruise-rollout has not restarted"
@@ -115,7 +115,7 @@ jobs:
           set +e
           ./bin/ginkgo -timeout 60m -v --focus='Bluegreen Release - Deployment - Ingress' test/e2e
           retVal=$?
-          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
           restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
           if [ "${restartCount}" -eq "0" ];then
               echo "Kruise-rollout has not restarted"
@@ -133,7 +133,7 @@ jobs:
           set +e
           ./bin/ginkgo -timeout 60m -v --focus='Bluegreen Release - Cloneset - Ingress' test/e2e
           retVal=$?
-          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
           restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
           if [ "${restartCount}" -eq "0" ];then
               echo "Kruise-rollout has not restarted"

--- a/.github/workflows/e2e-v1beta1-bluegreen-1.23.yaml
+++ b/.github/workflows/e2e-v1beta1-bluegreen-1.23.yaml
@@ -97,7 +97,7 @@ jobs:
           set +e
           ./bin/ginkgo -timeout 60m -v --focus='bluegreen delete rollout case - autoscaling/v2 for v1.23' test/e2e
           retVal=$?
-          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
           restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
           if [ "${restartCount}" -eq "0" ];then
               echo "Kruise-rollout has not restarted"
@@ -115,7 +115,7 @@ jobs:
           set +e
           ./bin/ginkgo -timeout 60m -v --focus='Bluegreen Release - Deployment - Ingress' test/e2e
           retVal=$?
-          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
           restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
           if [ "${restartCount}" -eq "0" ];then
               echo "Kruise-rollout has not restarted"
@@ -133,7 +133,7 @@ jobs:
           set +e
           ./bin/ginkgo -timeout 60m -v --focus='Bluegreen Release - Cloneset - Ingress' test/e2e
           retVal=$?
-          # kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
+          kubectl get pod -n kruise-rollout --no-headers | grep manager | awk '{print $1}' | xargs kubectl logs -n kruise-rollout
           restartCount=$(kubectl get pod -n kruise-rollout --no-headers | awk '{print $4}')
           if [ "${restartCount}" -eq "0" ];then
               echo "Kruise-rollout has not restarted"

--- a/pkg/controller/batchrelease/batchrelease_executor.go
+++ b/pkg/controller/batchrelease/batchrelease_executor.go
@@ -160,7 +160,7 @@ func (r *Executor) progressBatches(release *v1beta1.BatchRelease, newStatus *v1b
 
 	case v1beta1.VerifyingBatchState:
 		// replicas/partition has been modified, should wait pod ready in this state.
-		err = workloadController.CheckBatchReady()
+		err = workloadController.EnsureBatchPodsReadyAndLabeled()
 		switch {
 		case err != nil:
 			// should go to upgrade state to do again to avoid dead wait.
@@ -175,7 +175,7 @@ func (r *Executor) progressBatches(release *v1beta1.BatchRelease, newStatus *v1b
 
 	case v1beta1.ReadyBatchState:
 		// replicas/partition may be modified even though ready, should recheck in this state.
-		err = workloadController.CheckBatchReady()
+		err = workloadController.EnsureBatchPodsReadyAndLabeled()
 		switch {
 		case err != nil:
 			// if the batch ready condition changed due to some reasons, just recalculate the current batch.

--- a/pkg/controller/batchrelease/control/bluegreenstyle/control_plane.go
+++ b/pkg/controller/batchrelease/control/bluegreenstyle/control_plane.go
@@ -107,7 +107,7 @@ func (rc *realBatchControlPlane) UpgradeBatch() error {
 	return nil
 }
 
-func (rc *realBatchControlPlane) CheckBatchReady() error {
+func (rc *realBatchControlPlane) EnsureBatchPodsReadyAndLabeled() error {
 	controller, err := rc.BuildController()
 	if err != nil {
 		return err

--- a/pkg/controller/batchrelease/control/bluegreenstyle/control_plane.go
+++ b/pkg/controller/batchrelease/control/bluegreenstyle/control_plane.go
@@ -104,7 +104,7 @@ func (rc *realBatchControlPlane) UpgradeBatch() error {
 		return err
 	}
 
-	return rc.patchPodLabels(batchContext)
+	return nil
 }
 
 func (rc *realBatchControlPlane) CheckBatchReady() error {
@@ -126,7 +126,9 @@ func (rc *realBatchControlPlane) CheckBatchReady() error {
 
 	klog.Infof("BatchRelease %v calculated context when check batch ready: %s",
 		klog.KObj(rc.release), batchContext.Log())
-
+	if err = rc.patchPodLabels(batchContext); err != nil {
+		klog.ErrorS(err, "failed to patch pod labels", "release", klog.KObj(rc.release))
+	}
 	return batchContext.IsBatchReady()
 }
 

--- a/pkg/controller/batchrelease/control/canarystyle/control_plane.go
+++ b/pkg/controller/batchrelease/control/canarystyle/control_plane.go
@@ -115,10 +115,10 @@ func (rc *realCanaryController) UpgradeBatch() error {
 		return err
 	}
 
-	return rc.patcher.PatchPodBatchLabel(batchContext)
+	return nil
 }
 
-func (rc *realCanaryController) CheckBatchReady() error {
+func (rc *realCanaryController) EnsureBatchPodsReadyAndLabeled() error {
 	stable, err := rc.BuildStableController()
 	if err != nil {
 		return err
@@ -143,7 +143,9 @@ func (rc *realCanaryController) CheckBatchReady() error {
 	}
 	klog.Infof("BatchRelease %v calculated context when check batch ready: %s",
 		klog.KObj(rc.release), batchContext.Log())
-
+	if err = rc.patcher.PatchPodBatchLabel(batchContext); err != nil {
+		klog.ErrorS(err, "failed to patch pod labels", "release", klog.KObj(rc.release))
+	}
 	return batchContext.IsBatchReady()
 }
 

--- a/pkg/controller/batchrelease/control/interface.go
+++ b/pkg/controller/batchrelease/control/interface.go
@@ -52,10 +52,10 @@ type Interface interface {
 	// it returns nil if the preparation is succeeded, else the preparation should retry.
 	UpgradeBatch() error
 
-	// CheckBatchReady checks how many replicas are ready to serve requests in the current batch.
+	// EnsureBatchPodsReadyAndLabeled checks how many replicas are ready to serve requests in the current batch.
 	// this function is tasked to do any initialization work on the resources.
 	// it returns nil if the preparation is succeeded, else the preparation should retry.
-	CheckBatchReady() error
+	EnsureBatchPodsReadyAndLabeled() error
 
 	// Finalize makes sure the resources are in a good final state.
 	// this function is tasked to do any initialization work on the resources.

--- a/pkg/controller/batchrelease/control/partitionstyle/control_plane.go
+++ b/pkg/controller/batchrelease/control/partitionstyle/control_plane.go
@@ -114,7 +114,7 @@ func (rc *realBatchControlPlane) UpgradeBatch() error {
 	return rc.patcher.PatchPodBatchLabel(batchContext)
 }
 
-func (rc *realBatchControlPlane) CheckBatchReady() error {
+func (rc *realBatchControlPlane) EnsureBatchPodsReadyAndLabeled() error {
 	controller, err := rc.BuildController()
 	if err != nil {
 		return err

--- a/test/e2e/rollout_v1beta1_test.go
+++ b/test/e2e/rollout_v1beta1_test.go
@@ -2329,9 +2329,9 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 				g.Expect(rollout.Status.BlueGreenStatus.UpdatedReadyReplicas).Should(BeNumerically("==", 3))
 			}).WithTimeout(time.Second * 60).WithPolling(time.Second * 3).Should(Succeed())
 			// ------ 50% maxSurge, scale up: from 5 to 6 ------
+			By("50%, scale up from 5 to 6")
 			workload.Spec.Replicas = utilpointer.Int32(6)
 			UpdateDeployment(workload)
-			By("scale up: from 5 to 6")
 			time.Sleep(time.Second * 3)
 			WaitDeploymentBlueGreenReplicas(workload)
 
@@ -2349,6 +2349,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.BlueGreenStatus.ObservedRolloutID, "1", 3)).Should(Succeed())
 
 			// ------ scale up: from 6 to 7 ------
+			By("50%, scale up from 6 to 7")
 			workload.Spec.Replicas = utilpointer.Int32(7)
 			UpdateDeployment(workload)
 			time.Sleep(time.Second * 3)
@@ -2365,9 +2366,9 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.BlueGreenStatus.ObservedRolloutID, "1", 4)).Should(Succeed())
 
 			// ------ scale up: from 7 to 8 ------
+			By("50%, scale up from 7 to 8")
 			workload.Spec.Replicas = utilpointer.Int32(8)
 			UpdateDeployment(workload)
-			By("scale up: from 7 to 8")
 			time.Sleep(time.Second * 3)
 			WaitDeploymentBlueGreenReplicas(workload)
 			// check rollout status
@@ -2382,9 +2383,9 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.BlueGreenStatus.ObservedRolloutID, "1", 4)).Should(Succeed())
 
 			// ------ scale down: from 8 to 4 ------
+			By("50%, scale down from 8 to 4")
 			workload.Spec.Replicas = utilpointer.Int32(4)
 			UpdateDeployment(workload)
-			By("scale down: from 8 to 4")
 			time.Sleep(time.Second * 3)
 			WaitDeploymentBlueGreenReplicas(workload)
 			// check rollout status
@@ -2426,6 +2427,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			}).WithTimeout(time.Second * 60).WithPolling(time.Second * 1).Should(Succeed())
 
 			// ------ scale up: from 4 to 7 ------
+			By("100%, scale up from 4 to 7")
 			workload.Spec.Replicas = utilpointer.Int32(7)
 			UpdateDeployment(workload)
 			time.Sleep(time.Second * 3)
@@ -2443,6 +2445,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.BlueGreenStatus.ObservedRolloutID, "2", 3)).Should(Succeed())
 
 			// ------ scale up: from 7 to 8 ------
+			By("100%, scale up from 7 to 8")
 			workload.Spec.Replicas = utilpointer.Int32(8)
 			UpdateDeployment(workload)
 			time.Sleep(time.Second * 3)
@@ -2460,6 +2463,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.BlueGreenStatus.ObservedRolloutID, "2", 4)).Should(Succeed())
 
 			// ------ scale down: from 8 to 4 ------
+			By("100%, scale down from 8 to 4")
 			workload.Spec.Replicas = utilpointer.Int32(4)
 			UpdateDeployment(workload)
 			time.Sleep(time.Second * 3)
@@ -2473,8 +2477,6 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(workload.Status.UpdatedReplicas).Should(BeNumerically("==", 4))
 			Expect(workload.Status.UnavailableReplicas).Should(BeNumerically("==", 8))
 			Expect(workload.Status.ReadyReplicas).Should(BeNumerically("==", 8))
-			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.BlueGreenStatus.ObservedRolloutID, "1", 2)).Should(Succeed())
-			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.BlueGreenStatus.ObservedRolloutID, "2", 2)).Should(Succeed())
 		})
 
 		It("bluegreen delete rollout case", func() {

--- a/test/e2e/rollout_v1beta1_test.go
+++ b/test/e2e/rollout_v1beta1_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	appsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	appsv1beta1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	"github.com/openkruise/rollouts/api/v1beta1"
@@ -48,6 +49,7 @@ import (
 )
 
 var _ = SIGDescribe("Rollout v1beta1", func() {
+	format.MaxLength = 0
 	var namespace string
 
 	DumpAllResources := func() {
@@ -384,24 +386,27 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			}
 
 			count := 0
+			podsMap := make(map[string]string)
 			for _, pod := range pods {
+				podsMap[pod.Name] = fmt.Sprintf("rolloutID:%s, batchID:%s, controllerRevisionHash:%s",
+					pod.Labels[v1beta1.RolloutIDLabel], pod.Labels[v1beta1.RolloutBatchIDLabel], pod.Labels[apps.ControllerRevisionHashLabelKey])
 				if pod.Labels[v1beta1.RolloutIDLabel] == rolloutID &&
 					pod.Labels[v1beta1.RolloutBatchIDLabel] == batchID {
 					count++
 				}
 			}
 			if count != expected {
-				return fmt.Errorf("expected %d pods with rolloutID %s and batchID %s, got %d", expected, rolloutID, batchID, count)
+				return fmt.Errorf("expected %d pods with rolloutID %s and batchID %s, got %d; all pods info: %s", expected, rolloutID, batchID, count, podsMap)
 			}
 			klog.InfoS("check pod batch label success", "count", count, "rolloutID", rolloutID, "batchID", batchID)
 			return nil
 		}
 		var err error
-		for i := 0; i < 120; i++ {
+		for i := 0; i < 15; i++ {
 			if err = fn(); err == nil {
 				return nil
 			}
-			time.Sleep(time.Second)
+			time.Sleep(2 * time.Second)
 		}
 		return err
 	}
@@ -493,6 +498,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			},
 		}
 		Expect(k8sClient.Create(context.TODO(), &ns)).Should(SatisfyAny(BeNil()))
+		klog.InfoS("Namespace created", "namespace", namespace)
 	})
 
 	AfterEach(func() {
@@ -2301,25 +2307,27 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			WaitRolloutStepPaused(rollout.Name, 1)
 			stableRevision := GetStableRSRevision(workload)
 			By(stableRevision)
-			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
-			Expect(rollout.Status.CanaryStatus).Should(BeNil())
-			Expect(rollout.Status.BlueGreenStatus.StableRevision).Should(Equal(stableRevision))
+			Eventually(func(g Gomega) {
+				g.Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+				g.Expect(rollout.Status.CanaryStatus).Should(BeNil())
+				g.Expect(rollout.Status.BlueGreenStatus.StableRevision).Should(Equal(stableRevision))
 
-			// check workload status & paused
-			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
-			Expect(workload.Status.UpdatedReplicas).Should(BeNumerically("==", 3))
-			Expect(workload.Status.UnavailableReplicas).Should(BeNumerically("==", 8))
-			Expect(workload.Status.ReadyReplicas).Should(BeNumerically("==", 8))
+				// check workload status & paused
+				g.Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+				g.Expect(workload.Status.UpdatedReplicas).Should(BeNumerically("==", 3))
+				g.Expect(workload.Status.UnavailableReplicas).Should(BeNumerically("==", 8))
+				g.Expect(workload.Status.ReadyReplicas).Should(BeNumerically("==", 8))
 
-			// check rollout status
-			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
-			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
-			Expect(rollout.Status.Phase).Should(Equal(v1beta1.RolloutPhaseProgressing))
-			Expect(rollout.Status.BlueGreenStatus.RolloutHash).Should(Equal(rollout.Annotations[util.RolloutHashAnnotation]))
-			Expect(rollout.Status.BlueGreenStatus.CurrentStepIndex).Should(BeNumerically("==", 1))
-			Expect(rollout.Status.BlueGreenStatus.NextStepIndex).Should(BeNumerically("==", 2))
-			Expect(rollout.Status.BlueGreenStatus.UpdatedReplicas).Should(BeNumerically("==", 3))
-			Expect(rollout.Status.BlueGreenStatus.UpdatedReadyReplicas).Should(BeNumerically("==", 3))
+				// check rollout status
+				g.Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+				g.Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+				g.Expect(rollout.Status.Phase).Should(Equal(v1beta1.RolloutPhaseProgressing))
+				g.Expect(rollout.Status.BlueGreenStatus.RolloutHash).Should(Equal(rollout.Annotations[util.RolloutHashAnnotation]))
+				g.Expect(rollout.Status.BlueGreenStatus.CurrentStepIndex).Should(BeNumerically("==", 1))
+				g.Expect(rollout.Status.BlueGreenStatus.NextStepIndex).Should(BeNumerically("==", 2))
+				g.Expect(rollout.Status.BlueGreenStatus.UpdatedReplicas).Should(BeNumerically("==", 3))
+				g.Expect(rollout.Status.BlueGreenStatus.UpdatedReadyReplicas).Should(BeNumerically("==", 3))
+			}).WithTimeout(time.Second * 60).WithPolling(time.Second * 3).Should(Succeed())
 			// ------ 50% maxSurge, scale up: from 5 to 6 ------
 			workload.Spec.Replicas = utilpointer.Int32(6)
 			UpdateDeployment(workload)
@@ -2397,23 +2405,25 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			WaitRolloutStepPaused(rollout.Name, 2)
 
 			// workload
-			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
-			Expect(workload.Status.UpdatedReplicas).Should(BeNumerically("==", 4))
-			Expect(workload.Status.UnavailableReplicas).Should(BeNumerically("==", 8))
-			Expect(workload.Status.ReadyReplicas).Should(BeNumerically("==", 8))
-			Expect(workload.Spec.Paused).Should(BeFalse())
-			Expect(workload.Spec.Strategy.Type).Should(Equal(apps.RollingUpdateDeploymentStrategyType))
-			Expect(workload.Spec.MinReadySeconds).Should(Equal(int32(v1beta1.MaxReadySeconds)))
-			Expect(*workload.Spec.ProgressDeadlineSeconds).Should(Equal(int32(v1beta1.MaxProgressSeconds)))
-			Expect(reflect.DeepEqual(workload.Spec.Strategy.RollingUpdate.MaxUnavailable, &intstr.IntOrString{Type: intstr.Int, IntVal: 0})).Should(BeTrue())
-			Expect(reflect.DeepEqual(workload.Spec.Strategy.RollingUpdate.MaxSurge, &intstr.IntOrString{Type: intstr.String, StrVal: "100%"})).Should(BeTrue())
+			Eventually(func(g Gomega) {
+				g.Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
+				g.Expect(workload.Status.UpdatedReplicas).Should(BeNumerically("==", 4))
+				g.Expect(workload.Status.UnavailableReplicas).Should(BeNumerically("==", 8))
+				g.Expect(workload.Status.ReadyReplicas).Should(BeNumerically("==", 8))
+				g.Expect(workload.Spec.Paused).Should(BeFalse())
+				g.Expect(workload.Spec.Strategy.Type).Should(Equal(apps.RollingUpdateDeploymentStrategyType))
+				g.Expect(workload.Spec.MinReadySeconds).Should(Equal(int32(v1beta1.MaxReadySeconds)))
+				g.Expect(*workload.Spec.ProgressDeadlineSeconds).Should(Equal(int32(v1beta1.MaxProgressSeconds)))
+				g.Expect(reflect.DeepEqual(workload.Spec.Strategy.RollingUpdate.MaxUnavailable, &intstr.IntOrString{Type: intstr.Int, IntVal: 0})).Should(BeTrue())
+				g.Expect(reflect.DeepEqual(workload.Spec.Strategy.RollingUpdate.MaxSurge, &intstr.IntOrString{Type: intstr.String, StrVal: "100%"})).Should(BeTrue())
 
-			// rollout
-			Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
-			Expect(rollout.Status.BlueGreenStatus.CurrentStepIndex).Should(BeNumerically("==", 2))
-			Expect(rollout.Status.BlueGreenStatus.NextStepIndex).Should(BeNumerically("==", 3))
-			Expect(rollout.Status.BlueGreenStatus.UpdatedReplicas).Should(BeNumerically("==", 4))
-			Expect(rollout.Status.BlueGreenStatus.UpdatedReadyReplicas).Should(BeNumerically("==", 4))
+				// rollout
+				g.Expect(GetObject(rollout.Name, rollout)).NotTo(HaveOccurred())
+				g.Expect(rollout.Status.BlueGreenStatus.CurrentStepIndex).Should(BeNumerically("==", 2))
+				g.Expect(rollout.Status.BlueGreenStatus.NextStepIndex).Should(BeNumerically("==", 3))
+				g.Expect(rollout.Status.BlueGreenStatus.UpdatedReplicas).Should(BeNumerically("==", 4))
+				g.Expect(rollout.Status.BlueGreenStatus.UpdatedReadyReplicas).Should(BeNumerically("==", 4))
+			}).WithTimeout(time.Second * 60).WithPolling(time.Second * 1).Should(Succeed())
 
 			// ------ scale up: from 4 to 7 ------
 			workload.Spec.Replicas = utilpointer.Int32(7)
@@ -2530,7 +2540,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(rollout.Status.BlueGreenStatus.UpdatedReadyReplicas).Should(BeNumerically("==", 3))
 
 			By("delete rollout and check deployment")
-			k8sClient.Delete(context.TODO(), rollout)
+			_ = k8sClient.Delete(context.TODO(), rollout)
 			WaitRolloutNotFound(rollout.Name)
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
 			// check annotation
@@ -2865,7 +2875,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(hpa.Spec.ScaleTargetRef.Name).Should(Equal(workload.Name + HPADisableSuffix))
 
 			By("delete rollout and check deployment")
-			k8sClient.Delete(context.TODO(), rollout)
+			_ = k8sClient.Delete(context.TODO(), rollout)
 			WaitRolloutNotFound(rollout.Name)
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
 			// check annotation
@@ -3689,7 +3699,7 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 
 			// ------ delete rollout ------
 			By("delete rollout and check deployment")
-			k8sClient.Delete(context.TODO(), rollout)
+			_ = k8sClient.Delete(context.TODO(), rollout)
 			WaitRolloutNotFound(rollout.Name)
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
 			// check workload annotation

--- a/test/e2e/rollout_v1beta1_test.go
+++ b/test/e2e/rollout_v1beta1_test.go
@@ -624,6 +624,9 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(GetObject(service.Name+"-canary", cIngress)).NotTo(HaveOccurred())
 			Expect(cIngress.Annotations[fmt.Sprintf("%s/canary", nginxIngressAnnotationDefaultPrefix)]).Should(Equal("true"))
 			Expect(cIngress.Annotations[fmt.Sprintf("%s/canary-weight", nginxIngressAnnotationDefaultPrefix)]).Should(Equal(removePercentageSign(*rollout.Spec.Strategy.Canary.Steps[3].Traffic)))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "1", 1))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "2", 1))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "3", 1))
 
 			// Jump to step 3
 			By("Jump to step 3")
@@ -820,7 +823,11 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(string(cond.Status)).Should(Equal(string(metav1.ConditionTrue)))
 			Expect(GetObject(workload.Name, workload)).NotTo(HaveOccurred())
 			WaitRolloutWorkloadGeneration(rollout.Name, workload.Generation)
-
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "1", 1))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "2", 1))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "3", 1))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "4", 1))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "5", 1))
 		})
 
 		// step1-> 2-> 3-> 4-> 3-(TrafficChange)-> 3-> 2-> 1-> 5
@@ -1561,6 +1568,9 @@ var _ = SIGDescribe("Rollout v1beta1", func() {
 			Expect(GetObject(service.Name+"-canary", cIngress)).NotTo(HaveOccurred())
 			Expect(cIngress.Annotations[fmt.Sprintf("%s/canary", nginxIngressAnnotationDefaultPrefix)]).Should(Equal("true"))
 			Expect(cIngress.Annotations[fmt.Sprintf("%s/canary-weight", nginxIngressAnnotationDefaultPrefix)]).Should(Equal(removePercentageSign(*rollout.Spec.Strategy.Canary.Steps[2].Traffic)))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "1", 1))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "2", 1))
+			Expect(CheckPodBatchLabelV2(namespace, workload.Spec.Selector, rollout.Status.CanaryStatus.ObservedRolloutID, "3", 1))
 
 			// remove step 2 3 4
 			By("Remove step 2 3 4")


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

The patchPodLabels operation is moved from UpgradeBatch to CheckBatchReady. The reason for doing this is that UpgradeBatch only modifies the replica information of the workload, and performing patchPodLabels here may not be able to promptly read the pods that have not been created; whereas CheckBatchReady will continuously check until all the expected Pods are ready, therefore the patch should be performed before the check.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Special notes for reviews
