### PR TITLE
 Keep Deployment paused on Rollout deletion

### DIFF
--- a/pkg/controller/batchrelease/control/partitionstyle/cloneset/control.go
+++ b/pkg/controller/batchrelease/control/partitionstyle/cloneset/control.go
@@ -32,7 +32,9 @@ import (
 	"github.com/openkruise/rollouts/pkg/controller/batchrelease/control"
 	"github.com/openkruise/rollouts/pkg/controller/batchrelease/control/partitionstyle"
 	"github.com/openkruise/rollouts/pkg/controller/batchrelease/labelpatch"
+	"github.com/openkruise/rollouts/pkg/feature"
 	"github.com/openkruise/rollouts/pkg/util"
+	utilfeature "github.com/openkruise/rollouts/pkg/util/feature"
 )
 
 type realController struct {
@@ -117,9 +119,14 @@ func (rc *realController) Finalize(release *v1beta1.BatchRelease) error {
 	}
 
 	var specBody string
+
 	// if batchPartition == nil, workload should be promoted.
 	if release.Spec.ReleasePlan.BatchPartition == nil {
-		specBody = `,"spec":{"updateStrategy":{"partition":null,"paused":false}}`
+		if utilfeature.DefaultMutableFeatureGate.Enabled(feature.KeepWorkloadPausedOnRolloutDeletion) {
+			specBody = `,"spec":{"updateStrategy":{"paused":false}}`
+		} else {
+			specBody = `,"spec":{"updateStrategy":{"partition":null,"paused":false}}`
+		}
 	}
 
 	body := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null}}%s}`, util.BatchReleaseControlAnnotation, specBody)

--- a/pkg/controller/batchrelease/control/partitionstyle/daemonset/control.go
+++ b/pkg/controller/batchrelease/control/partitionstyle/daemonset/control.go
@@ -16,7 +16,9 @@ import (
 	"github.com/openkruise/rollouts/pkg/controller/batchrelease/control"
 	"github.com/openkruise/rollouts/pkg/controller/batchrelease/control/partitionstyle"
 	"github.com/openkruise/rollouts/pkg/controller/batchrelease/labelpatch"
+	"github.com/openkruise/rollouts/pkg/feature"
 	"github.com/openkruise/rollouts/pkg/util"
+	utilfeature "github.com/openkruise/rollouts/pkg/util/feature"
 )
 
 type realController struct {
@@ -127,11 +129,13 @@ func (rc *realController) Finalize(release *v1beta1.BatchRelease) error {
 	var specBody string
 	// if batchPartition == nil, workload should be promoted.
 	if release.Spec.ReleasePlan.BatchPartition == nil {
-		specBody = `,"spec":{"updateStrategy":{"rollingUpdate": {"partition":null,"paused":false}}}`
+		if utilfeature.DefaultMutableFeatureGate.Enabled(feature.KeepWorkloadPausedOnRolloutDeletion) {
+			specBody = `,"spec":{"updateStrategy":{"rollingUpdate": {"paused":false}}}`
+		} else {
+			specBody = `,"spec":{"updateStrategy":{"rollingUpdate": {"partition":null,"paused":false}}}`
+		}
 	}
-
 	body := fmt.Sprintf(`{"metadata":{"annotations":{"%s":null}}%s}`, util.BatchReleaseControlAnnotation, specBody)
-
 	daemon := util.GetEmptyObjectWithKey(rc.object)
 	return rc.client.Patch(context.TODO(), daemon, client.RawPatch(types.MergePatchType, []byte(body)))
 }

--- a/pkg/controller/batchrelease/control/partitionstyle/deployment/control.go
+++ b/pkg/controller/batchrelease/control/partitionstyle/deployment/control.go
@@ -34,7 +34,9 @@ import (
 	"github.com/openkruise/rollouts/pkg/controller/batchrelease/control"
 	"github.com/openkruise/rollouts/pkg/controller/batchrelease/control/partitionstyle"
 	deploymentutil "github.com/openkruise/rollouts/pkg/controller/deployment/util"
+	"github.com/openkruise/rollouts/pkg/feature"
 	"github.com/openkruise/rollouts/pkg/util"
+	utilfeature "github.com/openkruise/rollouts/pkg/util/feature"
 	"github.com/openkruise/rollouts/pkg/util/patch"
 )
 
@@ -142,7 +144,9 @@ func (rc *realController) Finalize(release *v1beta1.BatchRelease) error {
 	patchData := patch.NewDeploymentPatch()
 	if release.Spec.ReleasePlan.BatchPartition == nil {
 		strategy := util.GetDeploymentStrategy(rc.object)
-		patchData.UpdatePaused(false)
+		if !utilfeature.DefaultMutableFeatureGate.Enabled(feature.KeepWorkloadPausedOnRolloutDeletion) {
+			patchData.UpdatePaused(false)
+		}
 		if rc.object.Spec.Strategy.Type == apps.RecreateDeploymentStrategyType {
 			patchData.UpdateStrategy(apps.DeploymentStrategy{Type: apps.RollingUpdateDeploymentStrategyType, RollingUpdate: strategy.RollingUpdate})
 		}

--- a/pkg/feature/rollout_features.go
+++ b/pkg/feature/rollout_features.go
@@ -30,12 +30,16 @@ const (
 	AdvancedDeploymentGate featuregate.Feature = "AdvancedDeployment"
 	// AppendServiceSelectorGate enable appending pod labels from PodTemplateMetadata to the canary service selector.
 	AppendServiceSelectorGate featuregate.Feature = "AppendPodSelector"
+	// If the rollout CR is deleted during the rollout process, `pause=false` and `partition=0` will be set, causing the workload to complete deployment.
+	// If `KeepWorkloadPausedOnRolloutDeletion` is set, the state during deployment will be preserved(Keep partition > 0), enabling users to perform rollback operations.
+	KeepWorkloadPausedOnRolloutDeletion featuregate.Feature = "KeepWorkloadPausedOnRolloutDeletion"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	RolloutHistoryGate:        {Default: false, PreRelease: featuregate.Alpha},
-	AdvancedDeploymentGate:    {Default: false, PreRelease: featuregate.Alpha},
-	AppendServiceSelectorGate: {Default: false, PreRelease: featuregate.Alpha},
+	RolloutHistoryGate:                  {Default: false, PreRelease: featuregate.Alpha},
+	AdvancedDeploymentGate:              {Default: false, PreRelease: featuregate.Alpha},
+	AppendServiceSelectorGate:           {Default: false, PreRelease: featuregate.Alpha},
+	KeepWorkloadPausedOnRolloutDeletion: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR addresses an issue where deleting a Rollout CR causes the controller to unpause the underlying Deployment, triggering an unexpected rolling update.

To solve this, a new feature has been added to keep the Deployment paused when its managing Rollout is deleted. This behavior is controlled by a new feature gate, KeepDeploymentPausedOnDeletionGate. When the gate is enabled, the rollout finalizer will skip the step that unpauses the Deployment, leaving it in its static, paused state. This change has been applied to both Canary and Blue-Green strategies for consistent behavior.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #272 

### Ⅲ. Special notes for reviews
- The key aspect of this change is the introduction of the KeepDeploymentPausedOnDeletionGate feature gate.

- The new behavior is disabled by default to ensure full backward compatibility.
Users must explicitly enable the feature gate to prevent the Deployment from being unpaused upon Rollout deletion. This makes the feature entirely opt-in.