### PR TITLE
Add AWS‑ALB ingress traffic routing support

### DIFF
--- a/api/v1alpha1/trafficrouting_types.go
+++ b/api/v1alpha1/trafficrouting_types.go
@@ -44,7 +44,7 @@ type TrafficRoutingRef struct {
 // IngressTrafficRouting configuration for ingress controller to control traffic routing
 type IngressTrafficRouting struct {
 	// ClassType refers to the type of `Ingress`.
-	// current support nginx, aliyun-alb. default is nginx.
+	// current support nginx, aliyun-alb, aws-alb. default is nginx.
 	// +optional
 	ClassType string `json:"classType,omitempty"`
 	// Name refers to the name of an `Ingress` resource in the same namespace as the `Rollout`

--- a/config/crd/bases/rollouts.kruise.io_trafficroutings.yaml
+++ b/config/crd/bases/rollouts.kruise.io_trafficroutings.yaml
@@ -93,8 +93,12 @@ spec:
                       properties:
                         classType:
                           description: ClassType refers to the type of `Ingress`.
-                            current support nginx, aliyun-alb. default is nginx.
+                            current support nginx, aliyun-alb, aws-alb. default is nginx.
                           type: string
+                          enum:
+                          - nginx
+                          - aliyun-alb
+                          - aws-alb
                         name:
                           description: Name refers to the name of an `Ingress` resource
                             in the same namespace as the `Rollout`

--- a/lua_configuration/trafficrouting_ingress/aws-alb.lua
+++ b/lua_configuration/trafficrouting_ingress/aws-alb.lua
@@ -1,0 +1,54 @@
+local annotations = obj.annotations or {}
+
+-- Remove any prior ALB canary annotations
+annotations["alb.ingress.kubernetes.io/actions.canary"]    = nil
+annotations["alb.ingress.kubernetes.io/conditions.canary"] = nil
+
+-- Compute weights
+local cw = tonumber(obj.weight) or 0
+if cw < 0 then cw = 0 end
+if cw > 100 then cw = 100 end
+local sw = 100 - cw
+
+-- Build the forward action with *both* target‐groups
+local action = {
+  Type = "forward",
+  ForwardConfig = {
+    TargetGroups = {
+      { ServiceName = obj.stableService, ServicePort = "80", Weight = sw },
+      { ServiceName = obj.canaryService, ServicePort = "80", Weight = cw },
+    }
+  }
+}
+annotations["alb.ingress.kubernetes.io/actions.canary"] = action
+
+-- Build conditions if any
+if obj.matches then
+  local conds = {}
+  for _, match in ipairs(obj.matches) do
+    for _, hdr in ipairs(match.headers or {}) do
+      if hdr.name == "canary-by-cookie" then
+        table.insert(conds, {
+          Field            = "http-cookie",
+          HttpCookieConfig = { CookieName = hdr.value, Values = { hdr.value } },
+        })
+      elseif hdr.name == "SourceIp" then
+        table.insert(conds, {
+          Field          = "source-ip",
+          SourceIpConfig = { Values = { hdr.value } },
+        })
+      else
+        table.insert(conds, {
+          Field = "http-header",
+          HttpHeaderConfig = {
+            HttpHeaderName = hdr.name,
+            Values         = { hdr.value },
+          },
+        })
+      end
+    end
+  end
+  annotations["alb.ingress.kubernetes.io/conditions.canary"] = conds
+end
+
+return annotations

--- a/pkg/trafficrouting/network/ingress/ingress.go
+++ b/pkg/trafficrouting/network/ingress/ingress.go
@@ -235,6 +235,7 @@ func (r *ingressController) executeLuaForCanary(annotations map[string]string, w
 		Annotations           map[string]string
 		Weight                string
 		Matches               []v1beta1.HttpRouteMatch
+		StableService         string
 		CanaryService         string
 		RequestHeaderModifier *gatewayv1beta1.HTTPHeaderFilter
 	}
@@ -242,6 +243,7 @@ func (r *ingressController) executeLuaForCanary(annotations map[string]string, w
 		Annotations:           annotations,
 		Weight:                fmt.Sprintf("%d", *weight),
 		Matches:               matches,
+		StableService:         r.conf.StableService,
 		CanaryService:         r.conf.CanaryService,
 		RequestHeaderModifier: headerModifier,
 	}

--- a/pkg/trafficrouting/network/ingress/ingress_test.go
+++ b/pkg/trafficrouting/network/ingress/ingress_test.go
@@ -188,6 +188,58 @@ var (
 				annotations[conditionKey] = json.encode(conditions)
 				return annotations
  			`,
+			fmt.Sprintf("%s.aws-alb", configuration.LuaTrafficRoutingIngressTypePrefix): `
+                -- aws-alb.lua
+                local annotations = obj.annotations or {}
+                annotations["alb.ingress.kubernetes.io/actions.canary"]    = nil
+                annotations["alb.ingress.kubernetes.io/conditions.canary"] = nil
+
+                local cw = tonumber(obj.weight) or 0
+                if cw < 0 then cw = 0 end
+                if cw > 100 then cw = 100 end
+                local sw = 100 - cw
+
+                local action = {
+                  Type = "forward",
+                  ForwardConfig = {
+                    TargetGroups = {
+                      { ServiceName = obj.stableService, ServicePort = "80", Weight = sw },
+                      { ServiceName = obj.canaryService, ServicePort = "80", Weight = cw },
+                    }
+                  }
+                }
+                annotations["alb.ingress.kubernetes.io/actions.canary"] = action
+
+                if obj.matches then
+                  local conds = {}
+                  for _, m in ipairs(obj.matches) do
+                    for _, hdr in ipairs(m.headers or {}) do
+                      if hdr.name == "canary-by-cookie" then
+                        table.insert(conds, {
+                          Field = "http-cookie",
+                          HttpCookieConfig = { CookieName = hdr.value, Values = { hdr.value } }
+                        })
+                      elseif hdr.name == "SourceIp" then
+                        table.insert(conds, {
+                          Field = "source-ip",
+                          SourceIpConfig = { Values = { hdr.value } }
+                        })
+                      else
+                        table.insert(conds, {
+                          Field = "http-header",
+                          HttpHeaderConfig = {
+                            HttpHeaderName = hdr.name,
+                            Values         = { hdr.value }
+                          }
+                        })
+                      end
+                    end
+                  end
+                  annotations["alb.ingress.kubernetes.io/conditions.canary"] = conds
+                end
+
+                return annotations
+            `,
 		},
 	}
 
@@ -655,6 +707,52 @@ func TestEnsureRoutes(t *testing.T) {
 				expect.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name = "echoserver-canary"
 				expect.Spec.Rules[1].HTTP.Paths[0].Backend.Service.Name = "echoserver-canary"
 				return expect
+			},
+		},
+		{
+			name:        "ensure routes test aws-alb forward+conditions",
+			ingressType: "aws-alb",
+			getConfigmap: func() *corev1.ConfigMap {
+				return demoConf.DeepCopy()
+			},
+			getIngress: func() []*netv1.Ingress {
+				canary := demoIngress.DeepCopy()
+				canary.Name = "echoserver-canary"
+
+				// Expect both stable(80%) and canary(0%) in JSON
+				canary.Annotations["alb.ingress.kubernetes.io/actions.canary"] =
+					`{"Type":"forward","ForwardConfig":{"TargetGroups":[{"ServiceName":"echoserver","ServicePort":"80","Weight":100},{"ServiceName":"echoserver-canary","ServicePort":"80","Weight":0}]}}`
+				// And any header‐match condition
+				canary.Annotations["alb.ingress.kubernetes.io/conditions.canary"] =
+					`[{"Field":"http-header","HttpHeaderConfig":{"HttpHeaderName":"user_id","Values":["123456"]}}]`
+
+				canary.Spec.Rules[0].HTTP.Paths = canary.Spec.Rules[0].HTTP.Paths[:1]
+				canary.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name = "echoserver-canary"
+				return []*netv1.Ingress{demoIngress.DeepCopy(), canary}
+			},
+			getRoutes: func() *v1beta1.CanaryStep {
+				return &v1beta1.CanaryStep{
+					TrafficRoutingStrategy: v1beta1.TrafficRoutingStrategy{
+						Weight: utilpointer.Int32Ptr(0),
+						Matches: []v1beta1.HttpRouteMatch{{
+							Headers: []gatewayv1beta1.HTTPHeaderMatch{{
+								Name:  "user_id",
+								Value: "123456",
+							}},
+						}},
+					},
+				}
+			},
+			expectIngress: func() *netv1.Ingress {
+				e := demoIngress.DeepCopy()
+				e.Name = "echoserver-canary"
+				e.Annotations = map[string]string{
+					"alb.ingress.kubernetes.io/actions.canary":    `{"Type":"forward","ForwardConfig":{"TargetGroups":[{"ServiceName":"echoserver","ServicePort":"80","Weight":100},{"ServiceName":"echoserver-canary","ServicePort":"80","Weight":0}]}}`,
+					"alb.ingress.kubernetes.io/conditions.canary": `[{"Field":"http-header","HttpHeaderConfig":{"HttpHeaderName":"user_id","Values":["123456"]}}]`,
+				}
+				e.Spec.Rules[0].HTTP.Paths = e.Spec.Rules[0].HTTP.Paths[:1]
+				e.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name = "echoserver-canary"
+				return e
 			},
 		},
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- Extends the classType enum in the CRD to include aws-alb.

- Updates the Go API types’ documentation to mention aws-alb.

- Adds a new `lua_configuration/trafficrouting_ingress/aws-alb.lua` script that builds a weighted forward action with both stable and canary target groups, plus optional header/cookie/sourceIP conditions.

- Modifies the controller to pass both StableService and CanaryService into the Lua context.

- Extends unit tests (ingress_test.go) to load the new Lua script and validates the AWS‑ALB annotations JSON.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #129 

### Ⅲ. Special notes for reviews
Verify that the Lua script produces valid AWS ALB Controller annotations.
