### PR TITLE
Add unit tests for util functions

### DIFF
--- a/pkg/webhook/util/util_test.go
+++ b/pkg/webhook/util/util_test.go
@@ -1,0 +1,94 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGettersWithDefaults(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		funcName     string
+		envVarName   string
+		getterFunc   func() string
+		defaultValue string
+		setValue     string
+	}{
+		{
+			testName:     "GetNamespace with env var set",
+			funcName:     "GetNamespace",
+			envVarName:   "POD_NAMESPACE",
+			getterFunc:   GetNamespace,
+			defaultValue: "kruise-rollout",
+			setValue:     "my-namespace",
+		},
+		{
+			testName:     "GetSecretName with env var set",
+			funcName:     "GetSecretName",
+			envVarName:   "SECRET_NAME",
+			getterFunc:   GetSecretName,
+			defaultValue: "kruise-rollout-webhook-certs",
+			setValue:     "my-secret",
+		},
+		{
+			testName:     "GetServiceName with env var set",
+			funcName:     "GetServiceName",
+			envVarName:   "SERVICE_NAME",
+			getterFunc:   GetServiceName,
+			defaultValue: "kruise-rollout-webhook-service",
+			setValue:     "my-service",
+		},
+		{
+			testName:     "GetCertDir with env var set",
+			funcName:     "GetCertDir",
+			envVarName:   "WEBHOOK_CERT_DIR",
+			getterFunc:   GetCertDir,
+			defaultValue: "/tmp/kruise-rollout-webhook-certs",
+			setValue:     "/custom/cert/dir",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			t.Setenv(tc.envVarName, tc.setValue)
+			assert.Equal(t, tc.setValue, tc.getterFunc())
+		})
+
+		defaultCaseName := tc.funcName + " with default value"
+		t.Run(defaultCaseName, func(t *testing.T) {
+			assert.Equal(t, tc.defaultValue, tc.getterFunc())
+		})
+	}
+}
+
+func TestGetPort(t *testing.T) {
+	t.Run("should return default port when env var is not set", func(t *testing.T) {
+		port := GetPort()
+		assert.Equal(t, 9876, port)
+	})
+
+	t.Run("should return port from env var when set correctly", func(t *testing.T) {
+		t.Setenv("WEBHOOK_PORT", "8080")
+		port := GetPort()
+		assert.Equal(t, 8080, port)
+	})
+
+}
+
+func TestSimpleGetters(t *testing.T) {
+	t.Run("GetHost should return value from env var", func(t *testing.T) {
+		expectedHost := "my-test-host"
+		t.Setenv("WEBHOOK_HOST", expectedHost)
+		assert.Equal(t, expectedHost, GetHost())
+	})
+
+	t.Run("GetHost should return empty string if not set", func(t *testing.T) {
+		assert.Empty(t, GetHost())
+	})
+
+	t.Run("GetCertWriter should return value from env var", func(t *testing.T) {
+		t.Setenv("WEBHOOK_CERT_WRITER", "true")
+		assert.Equal(t, "true", GetCertWriter())
+	})
+}


### PR DESCRIPTION
**What this PR does / Why we need it**
The utility functions in `pkg/webhook/util/util.go` are responsible for configuring the webhook from environment variables. These functions previously lacked unit test coverage, making it hard to verify their behavior or prevent future regressions.

This PR adds unit tests to ensure this critical configuration logic is reliable and works as expected.

**Key Scenarios Covered**
- Functions correctly return a default value when an environment variable is not set.
- Functions correctly return the value from a set environment variable.
- The GetPort function is tested for both its default behavior and for correctly parsing a valid integer from the WEBHOOK_PORT environment variable.
