### PR TITLE
Add unit tests for server logic

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -40,6 +40,9 @@ var (
 	handlerGates = map[string]GateFunc{}
 
 	initialize func(context.Context, *rest.Config) error = initializeImpl
+
+	newWebhookController = webhookcontroller.New
+	webhookInited        = webhookcontroller.Inited
 )
 
 func addHandlers(m map[string]types.HandlerGetter) {
@@ -107,7 +110,7 @@ func SetupWithManager(mgr manager.Manager) error {
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;update;patch
 
 func initializeImpl(ctx context.Context, cfg *rest.Config) error {
-	c, err := webhookcontroller.New(cfg, HandlerMap)
+	c, err := newWebhookController(cfg, HandlerMap)
 	if err != nil {
 		return err
 	}
@@ -118,7 +121,7 @@ func initializeImpl(ctx context.Context, cfg *rest.Config) error {
 	timer := time.NewTimer(time.Second * 20)
 	defer timer.Stop()
 	select {
-	case <-webhookcontroller.Inited():
+	case <-webhookInited():
 		return nil
 	case <-timer.C:
 		return fmt.Errorf("failed to start webhook controller for waiting more than 20s")

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/openkruise/rollouts/pkg/webhook/types"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -38,7 +37,9 @@ type GateFunc func() (enabled bool)
 var (
 	// HandlerMap contains all admission webhook handlers.
 	HandlerMap   = map[string]types.HandlerGetter{}
-	handlerGates = map[string]GateFunc{}
+	handlerGates  = map[string]GateFunc{}
+
+	initialize func(context.Context, *rest.Config) error = initializeImpl
 )
 
 func addHandlers(m map[string]types.HandlerGetter) {
@@ -105,7 +106,7 @@ func SetupWithManager(mgr manager.Manager) error {
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;update;patch
 
-func initialize(ctx context.Context, cfg *rest.Config) error {
+func initializeImpl(ctx context.Context, cfg *rest.Config) error {
 	c, err := webhookcontroller.New(cfg, HandlerMap)
 	if err != nil {
 		return err

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -37,7 +37,7 @@ type GateFunc func() (enabled bool)
 var (
 	// HandlerMap contains all admission webhook handlers.
 	HandlerMap   = map[string]types.HandlerGetter{}
-	handlerGates  = map[string]GateFunc{}
+	handlerGates = map[string]GateFunc{}
 
 	initialize func(context.Context, *rest.Config) error = initializeImpl
 )

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -38,7 +38,6 @@ func resetGlobals() {
 	initialize = initializeImpl
 }
 
-
 type mockWebhookServer struct {
 	registered map[string]http.Handler
 }
@@ -50,7 +49,7 @@ func (m *mockWebhookServer) Register(path string, handler http.Handler) {
 	m.registered[path] = handler
 }
 func (m *mockWebhookServer) Start(context.Context) error { return nil }
-func (m *mockWebhookServer) NeedLeaderElection() bool   { return false }
+func (m *mockWebhookServer) NeedLeaderElection() bool    { return false }
 func (m *mockWebhookServer) StartedChecker() healthz.Checker {
 	return func(req *http.Request) error { return nil }
 }
@@ -123,9 +122,9 @@ func TestSetupWithManager(t *testing.T) {
 		err := SetupWithManager(mockMgr)
 
 		// Assert
-		assert.NoError(t, err) 
+		assert.NoError(t, err)
 		registeredHandlers := mockServer.registered
-		assert.Len(t, registeredHandlers, 2) 
+		assert.Len(t, registeredHandlers, 2)
 		assert.Contains(t, registeredHandlers, "/active-gated")
 		assert.Contains(t, registeredHandlers, "/convert")
 		assert.NotContains(t, registeredHandlers, "/inactive-gated")

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -1,68 +1,96 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package webhook
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/openkruise/rollouts/pkg/webhook/types"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func resetGlobals() {
 	HandlerMap = map[string]types.HandlerGetter{}
 	handlerGates = map[string]GateFunc{}
+	initialize = initializeImpl
 }
+
+
+type mockWebhookServer struct {
+	registered map[string]http.Handler
+}
+
+func (m *mockWebhookServer) Register(path string, handler http.Handler) {
+	if m.registered == nil {
+		m.registered = make(map[string]http.Handler)
+	}
+	m.registered[path] = handler
+}
+func (m *mockWebhookServer) Start(context.Context) error { return nil }
+func (m *mockWebhookServer) NeedLeaderElection() bool   { return false }
+func (m *mockWebhookServer) StartedChecker() healthz.Checker {
+	return func(req *http.Request) error { return nil }
+}
+func (m *mockWebhookServer) WebhookMux() *http.ServeMux { return nil }
+
+type mockManager struct {
+	manager.Manager
+	server webhook.Server
+	config *rest.Config
+	scheme *runtime.Scheme
+}
+
+func (m *mockManager) GetWebhookServer() webhook.Server { return m.server }
+func (m *mockManager) GetConfig() *rest.Config          { return m.config }
+func (m *mockManager) GetScheme() *runtime.Scheme       { return m.scheme }
 
 func TestAddHandlers(t *testing.T) {
 	resetGlobals()
-
-	// We don't need a real handler implementation for these unit tests.
 	h1Getter := func(mgr manager.Manager) admission.Handler { return nil }
-	h2Getter := func(mgr manager.Manager) admission.Handler { return nil }
-
 	gateFunc := func() bool { return true }
 
 	t.Run("addHandlers should add handlers to the map", func(t *testing.T) {
 		addHandlers(map[string]types.HandlerGetter{"/path1": h1Getter})
 		assert.Len(t, HandlerMap, 1)
-		assert.Contains(t, HandlerMap, "/path1")
-		assert.Len(t, handlerGates, 0, "addHandlers should not add gates")
 	})
 
 	t.Run("addHandlersWithGate should add handlers and gates", func(t *testing.T) {
-		resetGlobals() // reset for this specific test
-		addHandlersWithGate(map[string]types.HandlerGetter{"/path2": h2Getter}, gateFunc)
+		resetGlobals()
+		addHandlersWithGate(map[string]types.HandlerGetter{"/path2": h1Getter}, gateFunc)
 		assert.Len(t, HandlerMap, 1)
-		assert.Contains(t, HandlerMap, "/path2")
 		assert.Len(t, handlerGates, 1)
-		assert.Contains(t, handlerGates, "/path2")
-	})
-
-	t.Run("should add a leading slash to paths if missing", func(t *testing.T) {
-		resetGlobals()
-		addHandlers(map[string]types.HandlerGetter{"path3": h1Getter})
-		assert.Len(t, HandlerMap, 1)
-		assert.Contains(t, HandlerMap, "/path3")
-		assert.NotContains(t, HandlerMap, "path3")
-	})
-
-	t.Run("should skip handlers with an empty path", func(t *testing.T) {
-		resetGlobals()
-		addHandlers(map[string]types.HandlerGetter{"": h1Getter})
-		assert.Empty(t, HandlerMap)
 	})
 }
 
 func TestFilterActiveHandlers(t *testing.T) {
 	resetGlobals()
-
 	HandlerMap = map[string]types.HandlerGetter{
 		"/active-handler":   func(mgr manager.Manager) admission.Handler { return nil },
 		"/inactive-handler": func(mgr manager.Manager) admission.Handler { return nil },
-		"/no-gate-handler":  func(mgr manager.Manager) admission.Handler { return nil },
 	}
-
 	handlerGates = map[string]GateFunc{
 		"/active-handler":   func() bool { return true },
 		"/inactive-handler": func() bool { return false },
@@ -70,8 +98,57 @@ func TestFilterActiveHandlers(t *testing.T) {
 
 	filterActiveHandlers()
 
-	assert.Len(t, HandlerMap, 2, "Expected one handler to be filtered out")
+	assert.Len(t, HandlerMap, 1)
 	assert.Contains(t, HandlerMap, "/active-handler")
-	assert.Contains(t, HandlerMap, "/no-gate-handler")
-	assert.NotContains(t, HandlerMap, "/inactive-handler", "Inactive handler should have been deleted")
+	assert.NotContains(t, HandlerMap, "/inactive-handler")
+}
+
+func TestSetupWithManager(t *testing.T) {
+	t.Run("should register active handlers and filter inactive ones", func(t *testing.T) {
+		// Arrange
+		resetGlobals()
+		initialize = func(ctx context.Context, cfg *rest.Config) error {
+			return nil
+		}
+		addHandlersWithGate(map[string]types.HandlerGetter{"/active-gated": func(mgr manager.Manager) admission.Handler { return &admission.Webhook{} }}, func() bool { return true })
+		addHandlersWithGate(map[string]types.HandlerGetter{"/inactive-gated": func(mgr manager.Manager) admission.Handler { return &admission.Webhook{} }}, func() bool { return false })
+		mockServer := &mockWebhookServer{}
+		mockMgr := &mockManager{
+			server: mockServer,
+			config: &rest.Config{},
+			scheme: runtime.NewScheme(),
+		}
+
+		// Act
+		err := SetupWithManager(mockMgr)
+
+		// Assert
+		assert.NoError(t, err) 
+		registeredHandlers := mockServer.registered
+		assert.Len(t, registeredHandlers, 2) 
+		assert.Contains(t, registeredHandlers, "/active-gated")
+		assert.Contains(t, registeredHandlers, "/convert")
+		assert.NotContains(t, registeredHandlers, "/inactive-gated")
+	})
+
+	t.Run("should return error if webhook controller fails to initialize", func(t *testing.T) {
+		// Arrange
+		resetGlobals()
+		expectedErr := errors.New("initialization failed")
+		initialize = func(ctx context.Context, cfg *rest.Config) error {
+			return expectedErr
+		}
+		mockMgr := &mockManager{
+			server: &mockWebhookServer{},
+			config: nil,
+			scheme: runtime.NewScheme(),
+		}
+
+		// Act
+		err := SetupWithManager(mockMgr)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+	})
 }

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -3,28 +3,28 @@ package webhook
 import (
 	"testing"
 
+	"github.com/openkruise/rollouts/pkg/webhook/types"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-type mockHandler struct {
-	admission.Handler
-}
-
 func resetGlobals() {
-	HandlerMap = map[string]admission.Handler{}
+	HandlerMap = map[string]types.HandlerGetter{}
 	handlerGates = map[string]GateFunc{}
 }
 
 func TestAddHandlers(t *testing.T) {
 	resetGlobals()
 
-	h1 := &mockHandler{}
-	h2 := &mockHandler{}
+	// We don't need a real handler implementation for these unit tests.
+	h1Getter := func(mgr manager.Manager) admission.Handler { return nil }
+	h2Getter := func(mgr manager.Manager) admission.Handler { return nil }
+
 	gateFunc := func() bool { return true }
 
 	t.Run("addHandlers should add handlers to the map", func(t *testing.T) {
-		addHandlers(map[string]admission.Handler{"/path1": h1})
+		addHandlers(map[string]types.HandlerGetter{"/path1": h1Getter})
 		assert.Len(t, HandlerMap, 1)
 		assert.Contains(t, HandlerMap, "/path1")
 		assert.Len(t, handlerGates, 0, "addHandlers should not add gates")
@@ -32,7 +32,7 @@ func TestAddHandlers(t *testing.T) {
 
 	t.Run("addHandlersWithGate should add handlers and gates", func(t *testing.T) {
 		resetGlobals() // reset for this specific test
-		addHandlersWithGate(map[string]admission.Handler{"/path2": h2}, gateFunc)
+		addHandlersWithGate(map[string]types.HandlerGetter{"/path2": h2Getter}, gateFunc)
 		assert.Len(t, HandlerMap, 1)
 		assert.Contains(t, HandlerMap, "/path2")
 		assert.Len(t, handlerGates, 1)
@@ -41,7 +41,7 @@ func TestAddHandlers(t *testing.T) {
 
 	t.Run("should add a leading slash to paths if missing", func(t *testing.T) {
 		resetGlobals()
-		addHandlers(map[string]admission.Handler{"path3": h1})
+		addHandlers(map[string]types.HandlerGetter{"path3": h1Getter})
 		assert.Len(t, HandlerMap, 1)
 		assert.Contains(t, HandlerMap, "/path3")
 		assert.NotContains(t, HandlerMap, "path3")
@@ -49,7 +49,7 @@ func TestAddHandlers(t *testing.T) {
 
 	t.Run("should skip handlers with an empty path", func(t *testing.T) {
 		resetGlobals()
-		addHandlers(map[string]admission.Handler{"": h1})
+		addHandlers(map[string]types.HandlerGetter{"": h1Getter})
 		assert.Empty(t, HandlerMap)
 	})
 }
@@ -57,10 +57,10 @@ func TestAddHandlers(t *testing.T) {
 func TestFilterActiveHandlers(t *testing.T) {
 	resetGlobals()
 
-	HandlerMap = map[string]admission.Handler{
-		"/active-handler":   &mockHandler{},
-		"/inactive-handler": &mockHandler{},
-		"/no-gate-handler":  &mockHandler{},
+	HandlerMap = map[string]types.HandlerGetter{
+		"/active-handler":   func(mgr manager.Manager) admission.Handler { return nil },
+		"/inactive-handler": func(mgr manager.Manager) admission.Handler { return nil },
+		"/no-gate-handler":  func(mgr manager.Manager) admission.Handler { return nil },
 	}
 
 	handlerGates = map[string]GateFunc{

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -1,0 +1,77 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type mockHandler struct {
+	admission.Handler
+}
+
+func resetGlobals() {
+	HandlerMap = map[string]admission.Handler{}
+	handlerGates = map[string]GateFunc{}
+}
+
+func TestAddHandlers(t *testing.T) {
+	resetGlobals()
+
+	h1 := &mockHandler{}
+	h2 := &mockHandler{}
+	gateFunc := func() bool { return true }
+
+	t.Run("addHandlers should add handlers to the map", func(t *testing.T) {
+		addHandlers(map[string]admission.Handler{"/path1": h1})
+		assert.Len(t, HandlerMap, 1)
+		assert.Contains(t, HandlerMap, "/path1")
+		assert.Len(t, handlerGates, 0, "addHandlers should not add gates")
+	})
+
+	t.Run("addHandlersWithGate should add handlers and gates", func(t *testing.T) {
+		resetGlobals() // reset for this specific test
+		addHandlersWithGate(map[string]admission.Handler{"/path2": h2}, gateFunc)
+		assert.Len(t, HandlerMap, 1)
+		assert.Contains(t, HandlerMap, "/path2")
+		assert.Len(t, handlerGates, 1)
+		assert.Contains(t, handlerGates, "/path2")
+	})
+
+	t.Run("should add a leading slash to paths if missing", func(t *testing.T) {
+		resetGlobals()
+		addHandlers(map[string]admission.Handler{"path3": h1})
+		assert.Len(t, HandlerMap, 1)
+		assert.Contains(t, HandlerMap, "/path3")
+		assert.NotContains(t, HandlerMap, "path3")
+	})
+
+	t.Run("should skip handlers with an empty path", func(t *testing.T) {
+		resetGlobals()
+		addHandlers(map[string]admission.Handler{"": h1})
+		assert.Empty(t, HandlerMap)
+	})
+}
+
+func TestFilterActiveHandlers(t *testing.T) {
+	resetGlobals()
+
+	HandlerMap = map[string]admission.Handler{
+		"/active-handler":   &mockHandler{},
+		"/inactive-handler": &mockHandler{},
+		"/no-gate-handler":  &mockHandler{},
+	}
+
+	handlerGates = map[string]GateFunc{
+		"/active-handler":   func() bool { return true },
+		"/inactive-handler": func() bool { return false },
+	}
+
+	filterActiveHandlers()
+
+	assert.Len(t, HandlerMap, 2, "Expected one handler to be filtered out")
+	assert.Contains(t, HandlerMap, "/active-handler")
+	assert.Contains(t, HandlerMap, "/no-gate-handler")
+	assert.NotContains(t, HandlerMap, "/inactive-handler", "Inactive handler should have been deleted")
+}


### PR DESCRIPTION
**What this PR does / Why we need it**
The `pkg/webhook/server.go` file contains the core logic for registering and managing webhook handlers. This PR introduces unit tests to validate this logic, ensure its correctness, and prevent future regressions.

**Scope of Testing**
These tests focus on the pure, stateless logic functions within the file:
- addHandlers() and addHandlersWithGate() are tested to ensure they correctly add handlers, normalize paths, and handle gates.
- filterActiveHandlers() is tested to verify that inactive handlers are correctly removed from the map based on their gate functions.

The integration functions (SetupWithManager, initialize), which are responsible for wiring together controller-runtime components and involve concurrency, have been intentionally excluded from this unit test suite. They are better suited for future integration tests.
