### PR TITLE
Fix workload webhook filtering: patch label bug and add Kruise StatefulSet support

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -14,6 +14,10 @@ webhooks:
       path: /mutate-apps-kruise-io-v1alpha1-cloneset
   failurePolicy: Fail
   name: mcloneset.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: rollouts.kruise.io/workload-type
+      operator: Exists
   rules:
   - apiGroups:
     - apps.kruise.io
@@ -34,6 +38,10 @@ webhooks:
       path: /mutate-apps-kruise-io-v1alpha1-daemonset
   failurePolicy: Fail
   name: mdaemonset.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: rollouts.kruise.io/workload-type
+      operator: Exists
   rules:
   - apiGroups:
     - apps.kruise.io
@@ -54,6 +62,10 @@ webhooks:
       path: /mutate-apps-v1-deployment
   failurePolicy: Fail
   name: mdeployment.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: rollouts.kruise.io/workload-type
+      operator: Exists
   rules:
   - apiGroups:
     - apps
@@ -74,6 +86,10 @@ webhooks:
       path: /mutate-unified-workload
   failurePolicy: Fail
   name: munifiedworload.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: rollouts.kruise.io/workload-type
+      operator: Exists
   rules:
   - apiGroups:
     - '*'

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -14,10 +14,6 @@ webhooks:
       path: /mutate-apps-kruise-io-v1alpha1-cloneset
   failurePolicy: Fail
   name: mcloneset.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: rollouts.kruise.io/workload-type
-      operator: Exists
   rules:
   - apiGroups:
     - apps.kruise.io
@@ -38,10 +34,6 @@ webhooks:
       path: /mutate-apps-kruise-io-v1alpha1-daemonset
   failurePolicy: Fail
   name: mdaemonset.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: rollouts.kruise.io/workload-type
-      operator: Exists
   rules:
   - apiGroups:
     - apps.kruise.io
@@ -62,10 +54,6 @@ webhooks:
       path: /mutate-apps-v1-deployment
   failurePolicy: Fail
   name: mdeployment.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: rollouts.kruise.io/workload-type
-      operator: Exists
   rules:
   - apiGroups:
     - apps
@@ -86,10 +74,6 @@ webhooks:
       path: /mutate-unified-workload
   failurePolicy: Fail
   name: munifiedworload.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: rollouts.kruise.io/workload-type
-      operator: Exists
   rules:
   - apiGroups:
     - '*'

--- a/pkg/controller/rollout/rollout_status.go
+++ b/pkg/controller/rollout/rollout_status.go
@@ -298,10 +298,12 @@ func (r *RolloutReconciler) patchWorkloadRolloutWebhookLabel(rollout *v1beta1.Ro
 		workloadType = util.DeploymentType
 	case util.ControllerKindSts.Kind:
 		workloadType = util.StatefulSetType
+	case util.ControllerKruiseKindSts.Kind, util.ControllerKruiseOldKindSts.Kind:
+		workloadType = util.StatefulSetType
 	case util.ControllerKruiseKindDS.Kind:
 		workloadType = util.DaemonSetType
 	}
-	if workload.Annotations[util.WorkloadTypeLabel] == "" && workloadType != "" {
+	if workload.Labels[util.WorkloadTypeLabel] == "" && workloadType != "" {
 		workloadGVK := schema.FromAPIVersionAndKind(workload.APIVersion, workload.Kind)
 		obj := util.GetEmptyWorkloadObject(workloadGVK)
 		obj.SetNamespace(workload.Namespace)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
- Problem
  - Rollout webhooks were processing all workload updates, causing all workload updates to fail when kruise rollout crashes. The solution requires using `objectSelector` in MutatingWebhookConfiguration to filter workloads by the `rollouts.kruise.io/workload-type` label.
- Root Cause
  - The `patchWorkloadRolloutWebhookLabel` function had a bug - it was checking `workload.Annotations[util.WorkloadTypeLabel]` instead of `workload.Labels[util.WorkloadTypeLabel]`, preventing the label from being applied correctly.
- Testing
  - All existing unit tests pass
  - No regressions in webhook functionality
  - Verified label patching works for all workload types
  - Verified that `objectSelector` filtering was already properly configured in `config/webhook/patch_manifests.yaml`
### Ⅱ. Does this pull request fix one issue?
- fixes #152