### PR TITLE
Implement the TotalReplicas field for CanaryStatus

### DIFF
--- a/api/v1beta1/rollout_types.go
+++ b/api/v1beta1/rollout_types.go
@@ -445,6 +445,8 @@ type CanaryStatus struct {
 	CanaryReplicas int32 `json:"canaryReplicas"`
 	// CanaryReadyReplicas the numbers of ready canary revision pods
 	CanaryReadyReplicas int32 `json:"canaryReadyReplicas"`
+	// TotalReplicas the total number of replicas for the workload (including both stable and canary)
+	TotalReplicas int32 `json:"totalReplicas"`
 }
 
 // BlueGreenStatus status fields that only pertain to the blueGreen rollout

--- a/config/crd/bases/rollouts.kruise.io_rollouts.yaml
+++ b/config/crd/bases/rollouts.kruise.io_rollouts.yaml
@@ -1891,6 +1891,11 @@ spec:
                   stableRevision:
                     description: StableRevision indicates the revision of stable pods
                     type: string
+                  totalReplicas:
+                    description: TotalReplicas the total number of replicas for the
+                      workload (including both stable and canary)
+                    format: int32
+                    type: integer
                 required:
                 - canaryReadyReplicas
                 - canaryReplicas
@@ -1899,6 +1904,7 @@ spec:
                 - finalisingStep
                 - nextStepIndex
                 - podTemplateHash
+                - totalReplicas
                 type: object
               conditions:
                 description: Conditions a list of conditions a rollout can have.

--- a/pkg/controller/rollout/rollout_progressing.go
+++ b/pkg/controller/rollout/rollout_progressing.go
@@ -93,6 +93,7 @@ func (r *RolloutReconciler) reconcileRolloutProgressing(rollout *v1beta1.Rollout
 			newStatus.CanaryStatus = &v1beta1.CanaryStatus{
 				CommonStatus:   commonStatus,
 				CanaryRevision: rolloutContext.Workload.CanaryRevision,
+				TotalReplicas:  rolloutContext.Workload.Replicas,
 			}
 		}
 

--- a/pkg/controller/rollout/rollout_progressing_test.go
+++ b/pkg/controller/rollout/rollout_progressing_test.go
@@ -74,6 +74,7 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				s.CanaryStatus.NextStepIndex = 2
 				// now the first step is no longer StepStateUpgrade, it is StepStateInit now
 				s.CanaryStatus.CurrentStepState = v1beta1.CanaryStepStateInit
+				s.CanaryStatus.TotalReplicas = 10
 				s.CurrentStepIndex = s.CanaryStatus.CurrentStepIndex
 				s.CurrentStepState = s.CanaryStatus.CurrentStepState
 				s.CanaryStatus.ObservedRolloutID = "test-id"
@@ -111,6 +112,7 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 				s.CanaryStatus.CurrentStepIndex = 1
 				s.CanaryStatus.NextStepIndex = 2
 				s.CanaryStatus.CurrentStepState = v1beta1.CanaryStepStateInit
+				s.CanaryStatus.TotalReplicas = 10
 				s.CanaryStatus.ObservedRolloutID = "test-id"
 				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
 				cond.Reason = v1alpha1.ProgressingReasonInRolling

--- a/pkg/controller/rollout/rollout_status.go
+++ b/pkg/controller/rollout/rollout_status.go
@@ -143,6 +143,7 @@ func (r *RolloutReconciler) calculateRolloutStatus(rollout *v1beta1.Rollout) (re
 				newStatus.CanaryStatus = &v1beta1.CanaryStatus{
 					CommonStatus:   commonStatus,
 					CanaryRevision: workload.CanaryRevision,
+					TotalReplicas:  workload.Replicas,
 				}
 			}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
- Added `TotalReplicas` field to the `CanaryStatus` struct that provides direct access to the total number of replicas for the workload, especially useful when the workload is managed by HPA and replica count changes
- Verification: 
  - All new and existng tests passed
  - Project builds successfully
  - code generation works correctly
 
### Ⅱ. Does this pull request fix one issue?
- Fixes #145