### PR TITLE
Setting the UID of old object to new object, while using some CD tools(like OCM,Karmada) to update workload

### DIFF
--- a/pkg/webhook/workload/mutating/workload_update_handler.go
+++ b/pkg/webhook/workload/mutating/workload_update_handler.go
@@ -222,6 +222,11 @@ func (h *WorkloadHandler) Handle(ctx context.Context, req admission.Request) adm
 }
 
 func (h *WorkloadHandler) handleDeployment(newObj, oldObj *apps.Deployment) (bool, error) {
+	// if the resources is updated by CD tools(like OCM,Karmada), the uid of new object is empty
+	if len(newObj.GetUID()) == 0 {
+		newObj.SetUID(oldObj.GetUID())
+	}
+
 	// make sure matched Rollout CR always exists
 	rollout, err := h.fetchMatchedRollout(newObj)
 	if err != nil {
@@ -344,6 +349,11 @@ func (h *WorkloadHandler) handleCloneSet(newObj, oldObj *kruiseappsv1alpha1.Clon
 		return false, nil
 	}
 
+	// if the resources is updated by CD tools(like OCM,Karmada), the uid of new object is empty
+	if len(newObj.GetUID()) == 0 {
+		newObj.SetUID(oldObj.GetUID())
+	}
+
 	rollout, err := h.fetchMatchedRollout(newObj)
 	if err != nil {
 		return false, err
@@ -376,6 +386,11 @@ func (h *WorkloadHandler) handleDaemonSet(newObj, oldObj *kruiseappsv1alpha1.Dae
 		return false, nil
 	} else if newObj.Annotations[appsv1beta1.RolloutIDLabel] == "" && util.EqualIgnoreHash(&oldObj.Spec.Template, &newObj.Spec.Template) {
 		return false, nil
+	}
+
+	// if the resources is updated by CD tools(like OCM,Karmada), the uid of new object is empty
+	if len(newObj.GetUID()) == 0 {
+		newObj.SetUID(oldObj.GetUID())
 	}
 
 	rollout, err := h.fetchMatchedRollout(newObj)
@@ -498,6 +513,11 @@ func (h *WorkloadHandler) handleNativeDaemonSet(newObj, oldObj *apps.DaemonSet) 
 		return false, nil
 	} else if newObj.Annotations[appsv1beta1.RolloutIDLabel] == "" && util.EqualIgnoreHash(&oldObj.Spec.Template, &newObj.Spec.Template) {
 		return false, nil
+	}
+
+	// if the resources is updated by CD tools(like OCM,Karmada), the uid of new object is empty
+	if len(newObj.GetUID()) == 0 {
+		newObj.SetUID(oldObj.GetUID())
 	}
 
 	rollout, err := h.fetchMatchedRollout(newObj)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
If updating a deployment by some CD tools(like OCM,Karmada), the UID of new object often is empty. ReplicaSet will not match the deployment, and will `Cannot find any activate replicaset for deployment x/x, no need to rolling`.

https://github.com/openkruise/rollouts/blob/5b4889839dc4ba57acabf63ab357a50359faafcd/pkg/util/controller_finder.go#L500

### Ⅱ. Does this pull request fix one issue?
NONE
