### PR TITLE
fix: handle nil annotations in mse.lua

### DIFF
--- a/lua_configuration/trafficrouting_ingress/mse.lua
+++ b/lua_configuration/trafficrouting_ingress/mse.lua
@@ -4,7 +4,11 @@ function split(input, delimiter)
     return arr
 end
 
-annotations = obj.annotations
+annotations = {}
+if ( obj.annotations )
+then
+    annotations = obj.annotations
+end
 annotations["nginx.ingress.kubernetes.io/canary"] = "true"
 annotations["nginx.ingress.kubernetes.io/canary-by-cookie"] = nil
 annotations["nginx.ingress.kubernetes.io/canary-by-header"] = nil


### PR DESCRIPTION
Previously, `mse.lua` directly assigned `obj.annotations` to the annotations variable without checking for `nil`, which would cause a runtime error when the ingress object has no annotations. This aligns `mse.lua` with the nil-guard pattern already used in `higress.lua`, `nginx.lua`, and `aliyun-alb.lua`.

Fixes openkruise/rollouts#228
