### PR TITLE
Do your best to clean up the upgrade state when finish, otherwise, it may affect the next upgrade.

### DIFF
--- a/pkg/controller/batchrelease/control/partitionstyle/deployment/control.go
+++ b/pkg/controller/batchrelease/control/partitionstyle/deployment/control.go
@@ -136,7 +136,7 @@ func (rc *realController) Finalize(release *v1beta1.BatchRelease) error {
 	if rc.object == nil {
 		return nil // No need to finalize again.
 	}
-	isUnderRolloutControl := rc.object.Annotations[util.BatchReleaseControlAnnotation] != "" && rc.object.Spec.Paused
+	isUnderRolloutControl := rc.object.Annotations[util.BatchReleaseControlAnnotation] != ""
 	if !isUnderRolloutControl {
 		return nil // No need to finalize again.
 	}


### PR DESCRIPTION
https://github.com/openkruise/rollouts/issues/330


when use karmada sync deployment ;  batch release controller should clear up  rolling strategy when finish ;; 

But it maybe ignore this because karmada sync always and webhook not hook "spec.paused" field;;  it will affect next upgrade;

So the conditions for cleaning up the state after the upgrade should be more relaxed.

