### PR TITLE
fix: handle nil annotations in mse.lua

### DIFF
--- a/lua_configuration/trafficrouting_ingress/mse.lua
+++ b/lua_configuration/trafficrouting_ingress/mse.lua
@@ -4,7 +4,12 @@ function split(input, delimiter)
     return arr
 end
 
-annotations = obj.annotations
+annotations = {}
+-- obj.annotations is ingress annotations, handle nil case
+if ( obj.annotations )
+then
+    annotations = obj.annotations
+end
 annotations["nginx.ingress.kubernetes.io/canary"] = "true"
 annotations["nginx.ingress.kubernetes.io/canary-by-cookie"] = nil
 annotations["nginx.ingress.kubernetes.io/canary-by-header"] = nil


### PR DESCRIPTION
## What this PR does / why we need it

Added nil check for `obj.annotations` in `mse.lua` before using it. This follows the same pattern already used in `higress.lua` and prevents potential nil reference errors when annotations are not present.

## Which issue(s) this PR fixes

Fixes #228

## Changes made

Added nil handling for `obj.annotations` in `lua_configuration/trafficrouting_ingress/mse.lua`:

```lua
annotations = {}
-- obj.annotations is ingress annotations, handle nil case
if ( obj.annotations )
then
    annotations = obj.annotations
end
```

This matches the pattern used in `higress.lua` (line 1-6).

## Testing done

- [x] Verified the fix matches the pattern in higress.lua
- [x] No other code changes needed

## Does this PR introduce a user-facing change?

```release-note
NONE
```