### PR TITLE
fix: clear canaryStatus when rollback cancellation completes

### DIFF
--- a/pkg/controller/rollout/rollout_progressing.go
+++ b/pkg/controller/rollout/rollout_progressing.go
@@ -157,6 +157,17 @@ func (r *RolloutReconciler) reconcileRolloutProgressing(rollout *v1beta1.Rollout
 			return nil, err
 			// finalizer is finished
 		} else if done {
+			// Clear the canary/blueGreen sub-status: cancellation cleanup is
+			// finished and the workload is back on the stable revision, so the
+			// step-machine fields (CurrentStepIndex, CurrentStepState,
+			// PodTemplateHash, CanaryReplicas, ...) would otherwise remain
+			// frozen at the moment the rollback was triggered (e.g.
+			// "StepPaused" at step 1) for the lifetime of phase=Healthy.
+			// That misleads observers and breaks tooling that gates on
+			// canaryStatus (e.g. `kubectl kruise rollout approve` is a no-op
+			// once phase=Healthy). Mirror the cleanup that
+			// handleContinuousRelease performs for the same reason.
+			newStatus.Clear()
 			progressingStateTransition(newStatus, corev1.ConditionFalse, v1alpha1.ProgressingReasonCompleted, "Rollout progressing has been canceled")
 			setRolloutSucceededCondition(newStatus, corev1.ConditionFalse)
 		} else {

--- a/pkg/controller/rollout/rollout_progressing_test.go
+++ b/pkg/controller/rollout/rollout_progressing_test.go
@@ -758,6 +758,57 @@ func TestReconcileRolloutProgressing(t *testing.T) {
 			},
 		},
 		{
+			// Regression test for the case where a canary release is cancelled
+			// (workload rolled back directly). After doFinalising completes the
+			// rollback cleanup, the canaryStatus must be cleared so the rollout
+			// does not appear stuck at "step N paused" while phase is Healthy.
+			name: "ReconcileRolloutProgressing cancelling -> completed clears canaryStatus",
+			getObj: func() ([]*apps.Deployment, []*apps.ReplicaSet) {
+				// Workload is fully rolled back to v1 (stable image), no canary RS.
+				dep1 := deploymentDemo.DeepCopy()
+				dep1.Spec.Template.Spec.Containers[0].Image = "echoserver:v1"
+				rs1 := rsDemo.DeepCopy()
+				return []*apps.Deployment{dep1}, []*apps.ReplicaSet{rs1}
+			},
+			getNetwork: func() ([]*corev1.Service, []*netv1.Ingress) {
+				return []*corev1.Service{demoService.DeepCopy()}, []*netv1.Ingress{demoIngress.DeepCopy()}
+			},
+			getRollout: func() (*v1beta1.Rollout, *v1beta1.BatchRelease, *v1alpha1.TrafficRouting) {
+				obj := rolloutDemo.DeepCopy()
+				obj.Status.CanaryStatus.ObservedWorkloadGeneration = 2
+				obj.Status.CanaryStatus.RolloutHash = "f55bvd874d5f2fzvw46bv966x4bwbdv4wx6bd9f7b46ww788954b8z8w29b7wxfd"
+				obj.Status.CanaryStatus.StableRevision = "pod-template-hash-v1"
+				// Stale canary data left from the failed canary release.
+				obj.Status.CanaryStatus.CanaryRevision = "pod-template-hash-v1"
+				obj.Status.CanaryStatus.PodTemplateHash = "pod-template-hash-v2"
+				obj.Status.CanaryStatus.CurrentStepIndex = 1
+				obj.Status.CanaryStatus.CurrentStepState = v1beta1.CanaryStepStatePaused
+				obj.Status.CanaryStatus.CanaryReplicas = 1
+				obj.Status.CanaryStatus.CanaryReadyReplicas = 1
+				// FinalisingStep at the last rollback task so a single reconcile
+				// completes cancellation (next step is FinalisingStepTypeEnd).
+				obj.Status.CanaryStatus.FinalisingStep = v1beta1.FinalisingStepRemoveCanaryService
+				cond := util.GetRolloutCondition(obj.Status, v1beta1.RolloutConditionProgressing)
+				cond.Reason = v1alpha1.ProgressingReasonCancelling
+				cond.Status = corev1.ConditionTrue
+				util.SetRolloutCondition(&obj.Status, *cond)
+				return obj, nil, nil
+			},
+			expectStatus: func() *v1beta1.RolloutStatus {
+				s := rolloutDemo.Status.DeepCopy()
+				s.Clear()
+				cond := util.GetRolloutCondition(*s, v1beta1.RolloutConditionProgressing)
+				cond.Reason = v1alpha1.ProgressingReasonCompleted
+				cond.Status = corev1.ConditionFalse
+				util.SetRolloutCondition(s, *cond)
+				succeeded := util.NewRolloutCondition(v1beta1.RolloutConditionSucceeded, corev1.ConditionFalse, "", "")
+				succeeded.LastUpdateTime = metav1.Time{}
+				succeeded.LastTransitionTime = metav1.Time{}
+				util.SetRolloutCondition(s, *succeeded)
+				return s
+			},
+		},
+		{
 			name: "ReconcileRolloutProgressing rolling -> continueRelease2",
 			getObj: func() ([]*apps.Deployment, []*apps.ReplicaSet) {
 				dep1 := deploymentDemo.DeepCopy()


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When a canary release is cancelled via rollback-directly, `doFinalising` drains the `BatchRelease` and restores traffic routing correctly, but `canaryStatus` is left frozen at the step-machine state captured when the rollback was triggered (e.g. `currentStepIndex: 1, currentStepState: StepPaused, podTemplateHash: <failed-revision>`). The rollout settles into `phase: Healthy` with `Progressing: False / Completed`, yet the stale `canaryStatus` makes it look stuck at "step N paused", and `kubectl kruise rollout approve` is a no-op because the controller no longer dispatches `reconcileRolloutProgressing` while phase is Healthy.

This PR mirrors what `handleContinuousRelease` already does: clear the sub-status when the cancellation cleanup is complete, before flipping the `Progressing` condition to `Completed`.

### Ⅱ. Does this pull request fix one issue?

Fixes #339

### Ⅲ. Describe how to verify it

A regression test was added: `TestReconcileRolloutProgressing/ReconcileRolloutProgressing_cancelling_->_completed_clears_canaryStatus`.

It sets up a rollout mid-cancellation with stale canary status (`StepPaused` at step 1, `podTemplateHash` pointing at the failed revision, `canaryReplicas: 1`), drives `reconcileRolloutProgressing` through the last finalising step, and asserts that after `done=true` the rollout has:

- `Progressing: False / Completed`
- `Succeeded: False`
- `canaryStatus: nil`

Without the fix the test fails because the stale `canaryStatus` is preserved.

### Ⅳ. Special notes for reviews

The clear is intentionally scoped to the rollback/cancellation path (`ProgressingReasonCancelling` branch). The success path (`ProgressingReasonFinalising`) is left untouched because there the `canaryStatus` reflects the version that was actually deployed and is a useful observability artefact after a successful rollout.