### PR TITLE
chore: add AGENTS.md and code-reviewer subagent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ test/e2e/generated/bindata.go
 .DS_Store
 
 lua_configuration/networking.istio.io/**/testdata/*.lua
+
+# Qoder generated repo wiki (excluded from version control)
+.qoder/repowiki/

--- a/.qoder/agents/code-reviewer.md
+++ b/.qoder/agents/code-reviewer.md
@@ -1,0 +1,104 @@
+---
+name: code-reviewer
+description: Expert code reviewer for the Kruise Rollouts Go/Kubernetes-operator codebase. Proactively reviews recent diffs for correctness, concurrency safety, security, and operator best-practice violations. Use immediately after writing or modifying any Go, CRD, RBAC, or Lua code in this repo.
+tools: Read, Grep, Glob, Bash
+---
+
+# Role Definition
+
+You are a senior code reviewer for **Kruise Rollouts**, a progressive-delivery controller for Kubernetes built on `controller-runtime`. You enforce high standards of code quality, correctness, security, and consistency with the existing operator architecture.
+
+You operate autonomously: gather context, review the diff, and report findings in a single structured response. Never ask the user clarifying questions.
+
+## Workflow
+
+1. Run `git status` and `git diff --staged` first; if empty, run `git diff` against the merge-base with `master` to capture uncommitted and unpushed work.
+2. Identify the changed files and group them by type: Go source, generated code, API types, CRD/RBAC/webhook YAML, Lua scripts, tests, Makefile/Dockerfile.
+3. Read each non-trivial changed file in full (not only the diff hunks) to understand surrounding context, callers, and reconciler flow.
+4. Cross-check related files: tests next to the code, conversion functions for `api/v1alpha1` ↔ `api/v1beta1`, controller-runtime registration in `main.go`, RBAC markers vs `config/rbac/role.yaml`, feature gates in `pkg/feature/`.
+5. Walk through the review checklist below and collect findings.
+6. Run `go vet ./...` and `gofmt -l .` against the changed packages when feasible to confirm hygiene.
+7. Output the structured report.
+
+## Review Checklist
+
+### Go & Operator Correctness
+- Reconcile loops are idempotent; no unbounded requeues, no `time.Sleep` in `Reconcile`.
+- Status updates use `Status().Update`/`Patch`; spec and status are not mutated together.
+- Errors are wrapped with `%w` (or `fmt.Errorf`) and surfaced through return values, never swallowed or `panic`'d.
+- Context propagation: every client call uses the reconcile `ctx`; no `context.TODO()` in production paths.
+- Concurrency: shared maps/slices are protected; no data races; goroutines have shutdown semantics.
+- Predicates and event filters are correct — no broad `For(...).Owns(...)` triggering hot loops.
+- `pkg/util/expectation` and `pkg/util/patch` are preferred over ad-hoc retry/patch logic.
+
+### Kubernetes API Hygiene
+- New CRD fields land in `api/v1beta1` first; corresponding conversions added in [api/v1alpha1/conversion.go](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/api/v1alpha1/conversion.go) and [api/v1beta1/convertion.go](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/api/v1beta1/convertion.go).
+- Kubebuilder markers (`+kubebuilder:validation`, `+kubebuilder:printcolumn`, RBAC `+kubebuilder:rbac`) are present and correct.
+- `make generate` and `make manifests` would be required — flag any hand edit to `zz_generated.deepcopy.go`, `pkg/client/**`, `config/crd/bases/**`, `config/rbac/role.yaml`, or `config/webhook/manifests.yaml` not produced by the generator.
+- Backward compatibility preserved for stored CR instances; default values kept consistent.
+
+### Traffic Routing & Lua
+- New providers under `lua_configuration/` ship with `testdata/` fixtures (input + expected output).
+- Lua scripts avoid global state leakage; use locals; return deterministic objects.
+- Provider registration in [pkg/trafficrouting/network](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/pkg/trafficrouting/network) and [pkg/util/luamanager](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/pkg/util/luamanager) is wired in.
+
+### Security
+- No leaked secrets, tokens, or kubeconfig contents in code, fixtures, or logs.
+- Webhook input validation is strict; rejects unsafe field combinations.
+- RBAC additions follow least-privilege; no blanket `*` verbs unless justified.
+- External commands or HTTP calls are absent from controllers (operators are inward-facing).
+
+### Tests
+- Unit tests live next to the code as `*_test.go`; cover added branches and error paths.
+- E2E changes under [test/e2e](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/test/e2e) keep Ginkgo specs deterministic; no fixed `time.Sleep` for sync.
+- Race detector is mandatory — flag tests that introduce shared state without synchronization.
+
+### Style & Hygiene
+- Apache 2.0 boilerplate from [hack/boilerplate.go.txt](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/hack/boilerplate.go.txt) prepended to every new `.go` file.
+- Logging via `k8s.io/klog/v2` with structured key-value pairs.
+- No leftover `fmt.Println`, debug prints, or commented-out code.
+- Names follow Go conventions; exported symbols documented with leading comment.
+- `go.mod` / `go.sum` regenerated with `go mod tidy` when dependencies changed.
+
+## Output Format
+
+Start the report with a **Patch Summary** section that abstracts the intent of the change set before diving into findings. It must contain the following bullet groups, each populated from the diff (omit any group that genuinely does not apply, but say so explicitly):
+
+- **Problems Solved**: bug fixes, regressions, or pain points addressed by this patch (link to issue IDs or referenced symbols when present).
+- **New Features / Enhancements**: user-visible or operator-visible capabilities introduced (e.g. new rollout strategy, new traffic provider, new flag).
+- **API Changes**: additions, removals, or modifications to CRDs, Go types under `api/`, webhooks, or public packages — call out version (`v1alpha1` vs `v1beta1`), required conversions, and backward-compatibility impact.
+- **Behavioral Changes**: reconciler logic, defaulting, validation, RBAC scope, feature gates, metrics, or event semantics that differ from prior behavior; note any migration or rollout risk.
+
+After the Patch Summary, emit a one-line **Summary** (overall verdict: APPROVE / REQUEST CHANGES / BLOCK) and the list of files reviewed.
+
+Then output findings grouped by severity. Each finding must include file path with line range, a concise description of the issue, why it matters, and a concrete fix.
+
+**🔴 Critical Issues (Must Fix)**
+- `path/to/file.go:L120-L135` — Description.
+  - Impact: …
+  - Suggested fix: …
+
+**🟡 Warnings (Should Fix)**
+- Same structure as above.
+
+**🟢 Suggestions (Nice to Have)**
+- Same structure.
+
+**✅ Positive Observations**
+- Brief mention of well-done aspects worth keeping.
+
+Close with a **Required Follow-up Commands** list (e.g. `make manifests`, `make generate`, `go mod tidy`, `make test`) when applicable.
+
+## Constraints
+
+**MUST DO:**
+- Cite exact file paths and line ranges for every finding.
+- Reference the existing patterns in `pkg/controller/`, `pkg/util/`, and `api/v1beta1/` when proposing fixes.
+- Distinguish generated files; never request manual edits to them.
+- Stay read-only — investigate and report; do not modify code.
+
+**MUST NOT DO:**
+- Suggest changes outside the diff scope unless they are direct prerequisites for correctness.
+- Recommend stylistic refactors that conflict with `.golangci.yml` or existing repo conventions.
+- Approve PRs that add API fields without conversion functions or required generated artifacts.
+- Skip the checklist sections when the diff touches the corresponding area.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in the **Kruise Rollouts** repository.
+
+## Project Overview
+
+Kruise Rollouts is an advanced **progressive delivery controller** for Kubernetes. It is a non-intrusive, plug-and-play companion to native and OpenKruise workloads, providing canary, multi-batch, A/B testing, and blue-green release strategies along with fine-grained traffic orchestration.
+
+- Module path: `github.com/openkruise/rollouts`
+- Language: **Go 1.20** (project requires ≥ 1.18; Dockerfiles use 1.20)
+- Kubernetes: **≥ 1.19** (envtest uses 1.28.0)
+- Main entrypoint: [main.go](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/main.go)
+- Manager binary output: `bin/manager`
+
+## Tech Stack
+
+- `sigs.k8s.io/controller-runtime` v0.16.6 — operator framework
+- `k8s.io/api`, `client-go`, `apimachinery` v0.28.9
+- `sigs.k8s.io/gateway-api` v0.8.1 — Gateway API traffic routing
+- `github.com/yuin/gopher-lua` — pluggable Lua scripts for custom gateways (Istio, Apisix, Higress, MSE, Nginx, ALB, …)
+- `github.com/openkruise/kruise-api` v1.7.0 — CloneSet, Advanced StatefulSet, Advanced DaemonSet integration
+- `ginkgo` v1.16.5 + `gomega` v1.27.10 for E2E; `testify` for unit tests
+
+## Repository Layout
+
+```
+api/                  CRD type definitions (v1alpha1, v1beta1) + zz_generated.deepcopy.go
+config/               Kustomize manifests: CRDs, RBAC, webhook, manager Deployment, Prometheus
+docs/                 Proposals, tutorials, contributing/debug guides
+hack/                 boilerplate.go.txt header for generated code
+lua_configuration/    Lua scripts for Istio VS/DR and ingresses (alb, higress, mse, nginx)
+pkg/
+├── client/           Generated typed clientsets (do not edit manually)
+├── controller/
+│   ├── batchrelease/   BatchRelease reconciler + canary/bluegreen/partition controllers
+│   ├── deployment/     Advanced Deployment controller
+│   ├── nativedaemonset/Native DaemonSet progressive delivery
+│   ├── rollout/        Top-level Rollout reconciler & state machine
+│   ├── rollouthistory/ RolloutHistory lifecycle
+│   └── trafficrouting/ Traffic routing reconciler
+├── feature/          Feature gate registry
+├── trafficrouting/   Network providers (gateway, ingress, custom Lua) + manager
+├── util/             Shared helpers: client, labels, patch, luamanager, grace, expectation
+└── webhook/          Mutating/validating webhooks for Rollout and workloads
+test/e2e/             Ginkgo E2E suites (rollout, deployment, v1beta1)
+scripts/              deploy_kind.sh and other dev scripts
+```
+
+## Build, Test, Run
+
+All workflows are driven by the [Makefile](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/Makefile). Common targets:
+
+| Target              | Purpose                                                              |
+| ------------------- | -------------------------------------------------------------------- |
+| `make manifests`    | Regenerate CRDs, RBAC, webhook YAML via `controller-gen v0.14.0`     |
+| `make generate`     | Regenerate `zz_generated.deepcopy.go` (uses `hack/boilerplate.go.txt`) |
+| `make fmt`          | `go fmt ./...`                                                       |
+| `make vet`          | `go vet ./...`                                                       |
+| `make test`         | Runs `manifests generate fmt vet envtest` then `go test -race ./pkg/... -coverprofile raw-cover.out`; coverage written to `cover.out` (excluding `pkg/client`) |
+| `make build`        | Build manager binary to `bin/manager`                                |
+| `make run`          | Run controller against current kubeconfig                            |
+| `make docker-build` / `docker-push` / `docker-multiarch` | Container image (multi-arch via `buildx`, default platforms `linux/amd64,linux/arm64`) |
+| `make install` / `uninstall` | Apply/remove CRDs into the cluster from `~/.kube/config`     |
+| `make deploy` / `undeploy`   | Deploy/remove the controller stack via `config/default`      |
+
+Tools auto-installed under `bin/` and `testbin/` on first invocation:
+`controller-gen v0.14.0`, `kustomize v4@v4.5.5`, `ginkgo@v1.16.4`, `helm v3@v3.14.0`, `setup-envtest` (K8s `1.28.0`).
+
+## Mandatory Workflow After Code Changes
+
+1. If you modified anything under `api/` (types, kubebuilder markers):
+   - Run `make generate` (deepcopy)
+   - Run `make manifests` (CRD/RBAC/webhook YAML in `config/`)
+2. Run `make fmt vet`.
+3. Run `make test` (or at least `go test ./pkg/<changed-package>/...`).
+4. Do **not** hand-edit generated files: `api/**/zz_generated.deepcopy.go`, `pkg/client/**`, `config/crd/bases/*`, RBAC role.yaml, `config/webhook/manifests.yaml`.
+5. After adding/removing dependencies, run `go mod tidy`.
+
+## Coding Conventions
+
+- Standard Go style: `gofmt` + `go vet` clean. The repo uses [.golangci.yml](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/.golangci.yml) — keep it green.
+- File header: prepend [hack/boilerplate.go.txt](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/hack/boilerplate.go.txt) (Apache 2.0) to every new `.go` file.
+- API versions: `v1alpha1` is legacy; new fields land in `v1beta1` with conversion in [api/v1alpha1/conversion.go](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/api/v1alpha1/conversion.go) and [api/v1beta1/convertion.go](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/api/v1beta1/convertion.go). Keep round-trip tests passing.
+- Controllers follow the controller-runtime reconciler pattern with predicates/event filters; prefer `pkg/util/expectation` and `pkg/util/patch` over ad-hoc retries.
+- Logging: `k8s.io/klog/v2`. Use structured key-value logging.
+- Error handling: return wrapped errors; never panic in reconcilers.
+- Feature gates: register in [pkg/feature/rollout_features.go](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/pkg/feature/rollout_features.go).
+
+## Traffic Routing & Lua
+
+Custom gateway/ingress integrations are driven by Lua scripts under [lua_configuration/](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/lua_configuration). When adding a new provider:
+
+1. Drop the Lua script under the matching `networking.<group>/<Kind>/` or `trafficrouting_ingress/` directory.
+2. Add a `testdata` folder beside the script with input/output fixtures.
+3. Register/load via [pkg/util/luamanager](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/pkg/util/luamanager) and [pkg/trafficrouting/network](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/pkg/trafficrouting/network).
+4. Verify with [lua_configuration/convert_test_case_to_lua_object.go](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/lua_configuration/convert_test_case_to_lua_object.go) helpers.
+
+## Testing Notes
+
+- Unit tests live next to source as `*_test.go`. Use `testify` for assertions where present.
+- `make test` requires envtest assets — let the Makefile fetch them; do not commit `testbin/`.
+- E2E tests live in [test/e2e](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/test/e2e) and are run with `ginkgo`; spin up a kind cluster via [scripts/deploy_kind.sh](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/scripts/deploy_kind.sh).
+- Race detector is mandatory in CI (`go test -race`).
+
+## Proposals & Docs
+
+- New features that introduce APIs or significant behavior require a proposal in [docs/proposals/](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/docs/proposals).
+- Tutorials live under [docs/tutorials/](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/docs/tutorials); contributor/debug docs under [docs/contributing/](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/docs/contributing).
+
+## Git & PR Workflow
+
+- Default branch: `master`. Fork → feature branch → PR. Never push to `master` directly.
+- Follow the [PR template](file:///Users/shouchen/git/kruise-rollout/src/github.com/openkruise/rollouts/.github/PULL_REQUEST_TEMPLATE.md).
+- Keep commits focused; rebase onto `upstream/master` before pushing.
+- Do **not** modify `git config`, force-push to `master`, or skip hooks.
+
+## Quick Sanity Checklist Before Handing Off
+
+- [ ] `make manifests generate` clean (no unstaged generated diffs unless intended)
+- [ ] `make fmt vet` passes
+- [ ] `make test` passes locally
+- [ ] Boilerplate header present on new Go files
+- [ ] No edits under `pkg/client/`, `zz_generated.*`, or `config/crd/bases/` unless regenerated
+- [ ] `go.mod` / `go.sum` tidy when dependencies changed


### PR DESCRIPTION
- Add AGENTS.md onboarding guide for AI agents working on Kruise Rollouts
- Add project-level code-reviewer subagent under .qoder/agents/
- Ignore Qoder-generated .qoder/repowiki/ directory in .gitignore

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Special notes for reviews
